### PR TITLE
Fix off-by-one when dumping a whole segment

### DIFF
--- a/minidump/minidumpreader.py
+++ b/minidump/minidumpreader.py
@@ -17,7 +17,7 @@ class MinidumpBufferedMemorySegment:
 		self.data = file_handle.read(memory_segment.size)
 		
 	def inrange(self, position):
-		return self.start_address <= position < self.end_address
+		return self.start_address <= position <= self.end_address
 		
 	def remaining_len(self, position):
 		if not self.inrange(position):


### PR DESCRIPTION
A off-by-one bug prevent minidump from reading a whole memory segment.

Steps to reproduce :

```python
>>> from minidump.minidumpfile import MinidumpFile
>>> from minidump.common_structs import hexdump
>>> mf = MinidumpFile.parse("path_to_your_dump.dmp")
>>> reader = mf.get_reader()
>>> buff_reader = reader.get_buffered_reader()
>>> first_segment = mf.memory_segments_64.memory_segments[0]
>>> str(first_segment)
'VA Start: 0x7ffe0000, RVA: 0x4489, Size: 0x1000'
>>> buff_reader.move(first_segment.start_virtual_address)
>>> data = buff_reader.peek(first_segment.size)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dev/minidump/minidump/minidumpreader.py", line 115, in peek
    raise Exception('Would read over segment boundaries!')
Exception: Would read over segment boundaries!
>>> data = buff_reader.peek(first_segment.size-1)
>>> print(hexdump(data, start=first_segment.start_virtual_address))
# 7ffe0000(+0000):  00 00 00 00 00 00 a0 0f  68 66 30 8b 38 01 00 00   |........hf0.8...|
# 7ffe0010(+0010):  38 01 00 00 22 8f 3d 92  02 46 d5 01 02 46 d5 01   |8...".=..F...F..|
# 7ffe0020(+0020):  00 30 77 3c ef ff ff ff  ef ff ff ff 64 86 64 86   |.0w<........d.d.|
# 7ffe0030(+0030):  43 00 3a 00 5c 00 57 00  49 00 4e 00 44 00 4f 00   |C.:.\.W.I.N.D.O.|
# ....
```