### PR TITLE
Add support of parsing exception stream

### DIFF
--- a/minidump/__main__.py
+++ b/minidump/__main__.py
@@ -21,6 +21,7 @@ def run():
 	parser.add_argument('--memory', action='store_true', help='List memory')
 	parser.add_argument('--sysinfo', action='store_true', help='Show sysinfo')
 	parser.add_argument('--comments', action='store_true', help='Show comments')
+	parser.add_argument('--exception', action='store_true', help='Show exception records')
 	parser.add_argument('--handles', action='store_true', help='List handles')
 	parser.add_argument('--misc', action='store_true', help='Show misc info')
 	parser.add_argument('--all', action='store_true', help='Show all info')
@@ -60,6 +61,9 @@ def run():
 	if args.all or args.sysinfo:
 		if mf.sysinfo is not None:
 			print(str(mf.sysinfo))
+	if args.all or args.exception:
+		if mf.exception is not None:
+			print(str(mf.exception))
 	if args.all or args.comments:
 		if mf.comment_a is not None:
 			print(str(mf.comment_a))

--- a/minidump/minidumpfile.py
+++ b/minidump/minidumpfile.py
@@ -157,6 +157,7 @@ class MinidumpFile:
 		self.sysinfo = None
 		self.comment_a = None
 		self.comment_w = None
+		self.exception = None
 		self.handles = None
 		self.unloaded_modules = None
 		self.misc_info = None
@@ -236,6 +237,11 @@ class MinidumpFile:
 				self.comment_w = CommentStreamW.parse(dir, self.file_handle)
 				#logging.debug(str(self.comment_w))
 				continue
+			elif dir.StreamType == MINIDUMP_STREAM_TYPE.ExceptionStream:
+				logging.debug('Found ExceptionStream @%x Size: %d' % (dir.Location.Rva, dir.Location.DataSize))
+				self.exception = ExceptionList.parse(dir, self.file_handle)
+				#logging.debug(str(self.comment_w))
+				continue
 			elif dir.StreamType == MINIDUMP_STREAM_TYPE.HandleDataStream:
 				logging.debug('Found HandleDataStream @%x Size: %d' % (dir.Location.Rva, dir.Location.DataSize))
 				self.handles = MinidumpHandleDataStream.parse(dir, self.file_handle)
@@ -290,7 +296,7 @@ class MinidumpFile:
 			"""
 			elif dir.StreamType == MINIDUMP_STREAM_TYPE.HandleOperationListStream:
 			elif dir.StreamType == MINIDUMP_STREAM_TYPE.LastReservedStream:
-			elif dir.StreamType == MINIDUMP_STREAM_TYPE.ExceptionStream:
+			
 			"""
 
 	def __str__(self):

--- a/minidump/streams/ExceptionStream.py
+++ b/minidump/streams/ExceptionStream.py
@@ -5,6 +5,7 @@
 #
 # TODO: implement this better, the ExceptionInformation definition is missing on msdn :(
 
+import io
 import enum
 from minidump.common_structs import * 
 
@@ -24,28 +25,86 @@ class MINIDUMP_EXCEPTION_STREAM:
 		mes.ExceptionRecord = MINIDUMP_EXCEPTION.parse(buff)
 		mes.ThreadContext = MINIDUMP_LOCATION_DESCRIPTOR.parse(buff)
 		return mes
+
+	def __str__(self):
+		t  = '== MINIDUMP_EXCEPTION_STREAM ==\n'
+		t += 'ThreadId: %s\n' % self.ThreadId
+		# t += 'alignment: %s\n' % self.alignment
+		t += 'ExceptionRecord:\n %s\n' % str(self.ExceptionRecord)
+		t += 'ThreadContext: %s\n' % str(self.ThreadContext)
+		return t
+	
+	def get_header():
+		return [
+			'ThreadId',
+			*MINIDUMP_EXCEPTION.get_header()
+		]
+		
+
+	def to_row(self):
+		return [
+			'0x%08x' % self.ThreadId,
+			*self.ExceptionRecord.to_row()
+		]
+
 		
 class ExceptionCode(enum.Enum):
-	EXCEPTION_ACCESS_VIOLATION =  0xC0000005 #The thread tried to read from or write to a virtual address for which it does not have the appropriate access.
-	EXCEPTION_ARRAY_BOUNDS_EXCEEDED = 0xC000008C #The thread tried to access an array element that is out of bounds and the underlying hardware supports bounds checking.
-	EXCEPTION_BREAKPOINT = 0x80000003 #A breakpoint was encountered.
-	EXCEPTION_DATATYPE_MISALIGNMENT = 0x80000002 #The thread tried to read or write data that is misaligned on hardware that does not provide alignment. For example, 16-bit values must be aligned on 2-byte boundaries; 32-bit values on 4-byte boundaries, and so on.
-	EXCEPTION_FLT_DENORMAL_OPERAND = 0xC000008D#One of the operands in a floating-point operation is denormal. A denormal value is one that is too small to represent as a standard floating-point value.
-	EXCEPTION_FLT_DIVIDE_BY_ZERO = 0xC000008E#The thread tried to divide a floating-point value by a floating-point divisor of zero.
-	EXCEPTION_FLT_INEXACT_RESULT = 0xC000008F#The result of a floating-point operation cannot be represented exactly as a decimal fraction.
-	EXCEPTION_FLT_INVALID_OPERATION = 0xC0000090#This exception represents any floating-point exception not included in this list.
-	EXCEPTION_FLT_OVERFLOW = 0xC0000091#The exponent of a floating-point operation is greater than the magnitude allowed by the corresponding type.
-	EXCEPTION_FLT_STACK_CHECK = 0xC0000092#The stack overflowed or underflowed as the result of a floating-point operation.
-	EXCEPTION_FLT_UNDERFLOW = 0xC0000093#The exponent of a floating-point operation is less than the magnitude allowed by the corresponding type.
-	EXCEPTION_ILLEGAL_INSTRUCTION = 0xC000001D#The thread tried to execute an invalid instruction.
-	EXCEPTION_IN_PAGE_ERROR = 0xC0000006#The thread tried to access a page that was not present, and the system was unable to load the page. For example, this exception might occur if a network connection is lost while running a program over the network.
-	EXCEPTION_INT_DIVIDE_BY_ZERO = 0xC0000094#The thread tried to divide an integer value by an integer divisor of zero.
-	EXCEPTION_INT_OVERFLOW = 0xC0000095#The result of an integer operation caused a carry out of the most significant bit of the result.
-	EXCEPTION_INVALID_DISPOSITION = 0xC0000026#An exception handler returned an invalid disposition to the exception dispatcher. Programmers using a high-level language such as C should never encounter this exception.
-	EXCEPTION_NONCONTINUABLE_EXCEPTION =0xC0000025 #The thread tried to continue execution after a noncontinuable exception occurred.
-	EXCEPTION_PRIV_INSTRUCTION = 0xC0000096#The thread tried to execute an instruction whose operation is not allowed in the current machine mode.
-	EXCEPTION_SINGLE_STEP = 0x80000004#A trace trap or other single-instruction mechanism signaled that one instruction has been executed.
-	EXCEPTION_STACK_OVERFLOW = 0xC00000FD#The thread used up its stack.
+	# Not a real exception code, it's just a placeholder to prevent the parser from raising an error
+	EXCEPTION_NONE 					= 0x00
+
+	# Linux SIG values (for crashpad generated dumps)
+	EXCEPTION_SIGHUP    			= 0x00000001    # Hangup (POSIX)
+	EXCEPTION_SIGINT    			= 0x00000002    # Terminal interrupt (ANSI)
+	EXCEPTION_SIGQUIT   			= 0x00000003    # Terminal quit (POSIX)
+	EXCEPTION_SIGILL    			= 0x00000004    # Illegal instruction (ANSI)
+	EXCEPTION_SIGTRAP   			= 0x00000005    # Trace trap (POSIX)
+	EXCEPTION_SIGIOT    			= 0x00000006    # IOT Trap (4.2 BSD)
+	EXCEPTION_SIGBUS    			= 0x00000007    # BUS error (4.2 BSD)
+	EXCEPTION_SIGFPE    			= 0x00000008    # Floating point exception (ANSI)
+	EXCEPTION_SIGKILL   			= 0x00000009    # Kill(can't be caught or ignored) (POSIX)
+	EXCEPTION_SIGUSR1   			= 0x0000000A   # User defined signal 1 (POSIX)
+	EXCEPTION_SIGSEGV   			= 0x0000000B   # Invalid memory segment access (ANSI)
+	EXCEPTION_SIGUSR2   			= 0x0000000C   # User defined signal 2 (POSIX)
+	EXCEPTION_SIGPIPE   			= 0x0000000D   # Write on a pipe with no reader, Broken pipe (POSIX)
+	EXCEPTION_SIGALRM   			= 0x0000000E   # Alarm clock (POSIX)
+	EXCEPTION_SIGTERM   			= 0x0000000F   # Termination (ANSI)
+	EXCEPTION_SIGSTKFLT 			= 0x00000010   # Stack fault
+	EXCEPTION_SIGCHLD   			= 0x00000011   # Child process has stopped or exited, changed (POSIX)
+	EXCEPTION_SIGCONTV  			= 0x00000012   # Continue executing, if stopped (POSIX)
+	EXCEPTION_SIGSTOP   			= 0x00000013   # Stop executing(can't be caught or ignored) (POSIX)
+	EXCEPTION_SIGTSTP   			= 0x00000014   # Terminal stop signal (POSIX)
+	EXCEPTION_SIGTTIN   			= 0x00000015   # Background process trying to read, from TTY (POSIX)
+	EXCEPTION_SIGTTOU   			= 0x00000016   # Background process trying to write, to TTY (POSIX)
+	EXCEPTION_SIGURG    			= 0x00000017   # Urgent condition on socket (4.2 BSD)
+	EXCEPTION_SIGXCPU   			= 0x00000018   # CPU limit exceeded (4.2 BSD)
+	EXCEPTION_SIGXFSZ   			= 0x00000019   # File size limit exceeded (4.2 BSD)
+	EXCEPTION_SIGVTALRM 			= 0x0000001A   # Virtual alarm clock (4.2 BSD)
+	EXCEPTION_SIGPROF   			= 0x0000001B   # Profiling alarm clock (4.2 BSD)
+	EXCEPTION_SIGWINCH  			= 0x0000001C   # Window size change (4.3 BSD, Sun)
+	EXCEPTION_SIGIO     			= 0x0000001D   # I/O now possible (4.2 BSD)
+	EXCEPTION_SIGPWR    			= 0x0000001E   # Power failure restart (System V)
+
+	# Standard Windows exception values
+	EXCEPTION_ACCESS_VIOLATION 		= 0xC0000005 	# The thread tried to read from or write to a virtual address for which it does not have the appropriate access.
+	EXCEPTION_ARRAY_BOUNDS_EXCEEDED = 0xC000008C 	# The thread tried to access an array element that is out of bounds and the underlying hardware supports bounds checking.
+	EXCEPTION_BREAKPOINT 			= 0x80000003 	# A breakpoint was encountered.
+	EXCEPTION_DATATYPE_MISALIGNMENT = 0x80000002 	# The thread tried to read or write data that is misaligned on hardware that does not provide alignment. For example, 16-bit values must be aligned on 2-byte boundaries; 32-bit values on 4-byte boundaries, and so on.
+	EXCEPTION_FLT_DENORMAL_OPERAND 	= 0xC000008D 	# One of the operands in a floating-point operation is denormal. A denormal value is one that is too small to represent as a standard floating-point value.
+	EXCEPTION_FLT_DIVIDE_BY_ZERO 	= 0xC000008E	# The thread tried to divide a floating-point value by a floating-point divisor of zero.
+	EXCEPTION_FLT_INEXACT_RESULT 	= 0xC000008F	# The result of a floating-point operation cannot be represented exactly as a decimal fraction.
+	EXCEPTION_FLT_INVALID_OPERATION = 0xC0000090	# This exception represents any floating-point exception not included in this list.
+	EXCEPTION_FLT_OVERFLOW 			= 0xC0000091 	# The exponent of a floating-point operation is greater than the magnitude allowed by the corresponding type.
+	EXCEPTION_FLT_STACK_CHECK 		= 0xC0000092	# The stack overflowed or underflowed as the result of a floating-point operation.
+	EXCEPTION_FLT_UNDERFLOW 		= 0xC0000093	# The exponent of a floating-point operation is less than the magnitude allowed by the corresponding type.
+	EXCEPTION_ILLEGAL_INSTRUCTION 	= 0xC000001D	# The thread tried to execute an invalid instruction.
+	EXCEPTION_IN_PAGE_ERROR 		= 0xC0000006	# The thread tried to access a page that was not present, and the system was unable to load the page. For example, this exception might occur if a network connection is lost while running a program over the network.
+	EXCEPTION_INT_DIVIDE_BY_ZERO 	= 0xC0000094	# The thread tried to divide an integer value by an integer divisor of zero.
+	EXCEPTION_INT_OVERFLOW 			= 0xC0000095	# The result of an integer operation caused a carry out of the most significant bit of the result.
+	EXCEPTION_INVALID_DISPOSITION 	= 0xC0000026	# An exception handler returned an invalid disposition to the exception dispatcher. Programmers using a high-level language such as C should never encounter this exception.
+	EXCEPTION_NONCONTINUABLE_EXCEPTION =0xC0000025  # The thread tried to continue execution after a noncontinuable exception occurred.
+	EXCEPTION_PRIV_INSTRUCTION 		= 0xC0000096	# The thread tried to execute an instruction whose operation is not allowed in the current machine mode.
+	EXCEPTION_SINGLE_STEP 			= 0x80000004	# A trace trap or other single-instruction mechanism signaled that one instruction has been executed.
+	EXCEPTION_STACK_OVERFLOW 		= 0xC00000FD	# The thread used up its stack.
 		
 #https://msdn.microsoft.com/en-us/library/windows/desktop/ms680367(v=vs.85).aspx
 class MINIDUMP_EXCEPTION:
@@ -56,7 +115,7 @@ class MINIDUMP_EXCEPTION:
 		self.ExceptionAddress = None
 		self.NumberParameters = None
 		self.__unusedAlignment = None
-		#self.ExceptionInformation = []
+		self.ExceptionInformation = []
 		
 	def parse(buff):
 		me = MINIDUMP_EXCEPTION()
@@ -66,7 +125,77 @@ class MINIDUMP_EXCEPTION:
 		me.ExceptionAddress = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)
 		me.NumberParameters = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		me.__unusedAlignment = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
-		#for i in range(me.NumberParameters):
-		#	me.ExceptionInformation.append()
+		for i in range(me.NumberParameters):
+			me.ExceptionInformation.append(int.from_bytes(buff.read(8), byteorder = 'little', signed = False))
 			
 		return me
+
+	def __str__(self):
+		t  = '== MINIDUExceptionInformationMP_EXCEPTION ==\n'
+		t += "ExceptionCode : %s\n" % self.ExceptionCode 
+		t += "ExceptionFlags : %s\n" % self.ExceptionFlags 
+		t += "ExceptionRecord : %s\n" % self.ExceptionRecord
+		t += "ExceptionAddress : 0x%x\n" % self.ExceptionAddress
+		t += "NumberParameters : %s\n" % self.NumberParameters
+		# t += "__unusedAlignment : %s\n" % self.__unusedAlignment
+		t += "ExceptionInformation : %s\n" % ";".join("0x%x" % info for info in self.ExceptionInformation)
+		return t
+
+	def get_header():
+		return [
+			'ExceptionCode',
+			'ExceptionFlags',
+			'ExceptionRecord',
+			'ExceptionAddress',
+			'ExceptionInformation'
+		]
+		
+
+	def to_row(self):
+		return [
+			str(self.ExceptionCode),
+			'0x%08x' % self.ExceptionFlags,
+			'0x%08x' % self.ExceptionRecord,
+			'0x%08x' % self.ExceptionAddress,
+			str(self.ExceptionInformation)
+		]
+
+
+class ExceptionList:
+	def __init__(self):
+		self.exception_records = []
+		
+	def parse(dir, buff):
+		t = ExceptionList()
+	
+		buff.seek(dir.Location.Rva)
+		chunk = io.BytesIO(buff.read(dir.Location.DataSize))
+
+		# Unfortunately, we don't have a certain way to figure out how many exception records
+		# there is in the stream, so we have to fallback on heuristics (EOF or bad data read)
+		#
+		# NB : 	some tool only read one exception record : https://github.com/GregTheDev/MinidumpExplorer/blob/a6dd974757c16142eefcfff7d99be10b14f87eaf/MinidumpExplorer/MinidumpExplorer/MainForm.cs#L257
+		#		but it's incorrect since we can have an exception chain (double fault, exception catched and re-raised, etc.)
+		while chunk.tell() < dir.Location.DataSize:
+			mes = MINIDUMP_EXCEPTION_STREAM.parse(chunk)
+
+			# a minidump exception stream is usally padded with zeroes
+			# so whenever we parse an exception record with the code EXCEPTION_NONE
+			# we can stop.
+			if mes.ExceptionRecord.ExceptionCode == ExceptionCode.EXCEPTION_NONE:
+				break
+
+			t.exception_records.append(mes)
+			
+		return t
+	
+	def to_table(self):
+		t = []
+		t.append(MINIDUMP_EXCEPTION_STREAM.get_header())
+		for ex_record in self.exception_records:
+			t.append(ex_record.to_row())
+		return t
+
+	def __str__(self):
+		return '== ExceptionList ==\n' + construct_table(self.to_table())
+	

--- a/minidump/streams/__init__.py
+++ b/minidump/streams/__init__.py
@@ -24,7 +24,7 @@ from .UnloadedModuleListStream import *
 
 __CommentStreamA__ = ['CommentStreamA']
 __CommentStreamW__ = ['CommentStreamW']
-__ExceptionStream__ = []
+__ExceptionStream__ = ['ExceptionList']
 __FunctionTableStream__ = ['MINIDUMP_FUNCTION_TABLE_STREAM']
 __HandleDataStream__ = ['MinidumpHandleDataStream','MINIDUMP_HANDLE_DATA_STREAM']
 __HandleOperationListStream__ = ['MINIDUMP_HANDLE_OPERATION_LIST']


### PR DESCRIPTION
"Correctly" (this stream is not documented properly, so it's
implementation-dependant) parse exception stream in order to
extract exception chain records.

This is pretty important, since the information about a crash (
which then generated the crashdump) is stored in the exception stream.
This is the entry point to analyze automatically crash dumps.

Exemple of exception output : 

```
(minidump_env) lucasg@lucasg:~/minidump/minidump$ python -m minidump.__main__  --exception ../dump/fizzbuzz_no_heap.dmp 
== ExceptionList ==
ThreadId   | ExceptionCode                            | ExceptionFlags | ExceptionRecord | ExceptionAddress | ExceptionInformation
----------------------------------------------------------------------------------------------------------------------------------
0x00002320 | ExceptionCode.EXCEPTION_ACCESS_VIOLATION | 0x00000000     | 0x00000000      | 0x00164d14       | [0, 0]              
```

(the fizzbuzz crash dump can be found here : https://github.com/llvm-mirror/lldb/blob/master/packages/Python/lldbsuite/test/functionalities/postmortem/minidump/fizzbuzz_no_heap.dmp)
