### PR TITLE
[WIP] Add support for Crashpad/Breakpad minidump

### DIFF
--- a/minidump/minidumpfile.py
+++ b/minidump/minidumpfile.py
@@ -16,44 +16,44 @@ from .streams import *
 
 
 class MINIDUMP_STREAM_TYPE(enum.Enum):
-	UnusedStream			   = 0
-	ReservedStream0			= 1
-	ReservedStream1			= 2
-	ThreadListStream		   = 3
-	ModuleListStream		   = 4
-	MemoryListStream		   = 5
-	ExceptionStream			= 6
-	SystemInfoStream		   = 7
-	ThreadExListStream		 = 8
-	Memory64ListStream		 = 9
-	CommentStreamA			 = 10
-	CommentStreamW			 = 11
-	HandleDataStream		   = 12
-	FunctionTableStream		= 13
-	UnloadedModuleListStream   = 14
-	MiscInfoStream			 = 15
-	MemoryInfoListStream	   = 16
-	ThreadInfoListStream	   = 17
-	HandleOperationListStream  = 18
-	TokenStream = 19
-	JavaScriptDataStream = 20
-	SystemMemoryInfoStream = 21
-	ProcessVmCountersStream = 22
-	ThreadNamesStream = 24
-	ceStreamNull = 25
-	ceStreamSystemInfo = 26
-	ceStreamException = 27
-	ceStreamModuleList = 28
-	ceStreamProcessList = 29
-	ceStreamThreadList = 30
-	ceStreamThreadContextList = 31
+	UnusedStream			   	= 0
+	ReservedStream0				= 1
+	ReservedStream1				= 2
+	ThreadListStream		   	= 3
+	ModuleListStream		   	= 4
+	MemoryListStream		   	= 5
+	ExceptionStream				= 6
+	SystemInfoStream		   	= 7
+	ThreadExListStream		 	= 8
+	Memory64ListStream		 	= 9
+	CommentStreamA			 	= 10
+	CommentStreamW			 	= 11
+	HandleDataStream		   	= 12
+	FunctionTableStream			= 13
+	UnloadedModuleListStream   	= 14
+	MiscInfoStream			 	= 15
+	MemoryInfoListStream	   	= 16
+	ThreadInfoListStream	   	= 17
+	HandleOperationListStream  	= 18
+	TokenStream 				= 19
+	JavaScriptDataStream 		= 20
+	SystemMemoryInfoStream 		= 21
+	ProcessVmCountersStream 	= 22
+	ThreadNamesStream 			= 24
+	ceStreamNull 				= 25
+	ceStreamSystemInfo 			= 26
+	ceStreamException 			= 27
+	ceStreamModuleList 			= 28
+	ceStreamProcessList 		= 29
+	ceStreamThreadList 			= 30
+	ceStreamThreadContextList 	= 31
 	ceStreamThreadCallStackList = 32
-	ceStreamMemoryVirtualList = 33
-	ceStreamMemoryPhysicalList = 34
-	ceStreamBucketParameters = 35
-	ceStreamProcessModuleMap = 36
-	ceStreamDiagnosisList = 37
-	LastReservedStream		 = 0xffff
+	ceStreamMemoryVirtualList 	= 33
+	ceStreamMemoryPhysicalList 	= 34
+	ceStreamBucketParameters 	= 35
+	ceStreamProcessModuleMap 	= 36
+	ceStreamDiagnosisList 		= 37
+	LastReservedStream		 	= 0xffff
 
 class MINIDUMP_TYPE(enum.IntFlag):
 	MiniDumpNormal                         = 0x00000000
@@ -87,8 +87,17 @@ class MINIDUMP_DIRECTORY:
 
 	@staticmethod
 	def parse(buff):
+
+		raw_stream_type_value = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
+
+		# StreamType value that are over 0xffff are considered MINIDUMP_USER_STREAM streams
+		# and their format depends on the client used to create the minidump.
+		# As per the documentation, this stream should be ignored : https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ne-minidumpapiset-minidumminidump_dirp_stream_type#remarks
+		if raw_stream_type_value > MINIDUMP_STREAM_TYPE.LastReservedStream.value:
+			return None
+
 		md = MINIDUMP_DIRECTORY()
-		md.StreamType = MINIDUMP_STREAM_TYPE(int.from_bytes(buff.read(4), byteorder = 'little', signed = False))
+		md.StreamType = MINIDUMP_STREAM_TYPE(raw_stream_type_value)
 		md.Location = MINIDUMP_LOCATION_DESCRIPTOR.parse(buff)
 		return md
 
@@ -183,10 +192,12 @@ class MinidumpFile:
 		self.header = MinidumpHeader.parse(self.file_handle)
 		for i in range(0, self.header.NumberOfStreams):
 			self.file_handle.seek(self.header.StreamDirectoryRva + i * 12, 0 )
-			self.directories.append(MINIDUMP_DIRECTORY.parse(self.file_handle))
-
+			minidump_dir = MINIDUMP_DIRECTORY.parse(self.file_handle)
+			if minidump_dir:
+				self.directories.append(minidump_dir)
 
 	def __parse_directories(self):
+
 		for dir in self.directories:
 			if dir.StreamType == MINIDUMP_STREAM_TYPE.UnusedStream:
 				logging.debug('Found UnusedStream @%x Size: %d' % (dir.Location.Rva, dir.Location.DataSize))

--- a/minidump/streams/SystemInfoStream.py
+++ b/minidump/streams/SystemInfoStream.py
@@ -24,14 +24,28 @@ class PROCESSOR_LEVEL(enum.Enum):
 	INTEL_PENTIUM_PRO = 6 #or Pentium II
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms680396(v=vs.85).aspx	
 class PRODUCT_TYPE(enum.Enum):
-	VER_NT_DOMAIN_CONTROLLER = 0x0000002 #The system is a domain controller.
-	VER_NT_SERVER = 0x0000003 #The system is a server.
-	VER_NT_WORKSTATION = 0x0000001 #The system is running Windows XP, Windows Vista, Windows 7, or Windows 8.
+	VER_UNIDENTIFIED_PRODUCT 	= 0x0000000 # Crashpad des not set ProductType value on non-Windows systems
+	VER_NT_WORKSTATION 			= 0x0000001 # The system is running Windows XP, Windows Vista, Windows 7, or Windows 8.
+	VER_NT_DOMAIN_CONTROLLER 	= 0x0000002 # The system is a domain controller.
+	VER_NT_SERVER 				= 0x0000003 # The system is a server.
+	
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms680396(v=vs.85).aspx
 class PLATFORM_ID(enum.Enum):
 	VER_PLATFORM_WIN32s = 0 #Not supported
 	VER_PLATFORM_WIN32_WINDOWS = 1 #Not supported.
 	VER_PLATFORM_WIN32_NT = 2 #The operating system platform is Windows.
+	
+	# source : https://github.com/chromium/crashpad/blob/4b05be4265c0ffacfce26d7db7644ffbf9037696/minidump/minidump_extensions.h#L239
+	VER_PLATFORM_CRASHPAD_MAC       = 0x8101
+	VER_PLATFORM_CRASHPAD_IOS       = 0x8102
+	VER_PLATFORM_CRASHPAD_LINUX 	= 0x8201
+	VER_PLATFORM_CRASHPAD_SOLARIS 	= 0x8202
+	VER_PLATFORM_CRASHPAD_ANDROID 	= 0x8203
+	VER_PLATFORM_CRASHPAD_PS3       = 0x8204
+	VER_PLATFORM_CRASHPAD_NACL      = 0x8205
+	VER_PLATFORM_CRASHPAD_FUSCHIA 	= 0x8206
+	VER_PLATFORM_CRASHPAD_UNKNOWN 	= 0xffffffff
+
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms680396(v=vs.85).aspx
 class SUITE_MASK(enum.IntFlag):
 	VER_SUITE_BACKOFFICE = 0x00000004 #Microsoft BackOffice components are installed.


### PR DESCRIPTION
This is a work-in-progress, so feel free to merge it into the main tree at your leisure.

Breakpad and Crashpad generate minidumps on crash, but also add "user-specific" streams since, well, they have user-specific data. I didn't attempt to parse those streams yet, but I had to relax the stream directory parsing in order to skip unknown streams.