### PR TITLE
Add timestamps to module list dump

### DIFF
--- a/minidump/streams/ModuleListStream.py
+++ b/minidump/streams/ModuleListStream.py
@@ -59,6 +59,7 @@ class MinidumpModule:
 			'BaseAddress',
 			'Size',
 			'Endaddress',
+			'Timestamp',
 		]
 	
 	def to_row(self):
@@ -67,6 +68,7 @@ class MinidumpModule:
 			'0x%08x' % self.baseaddress,
 			hex(self.size),
 			'0x%08x' % self.endaddress,
+			'0x%08x' % self.timestamp,
 		]
 		
 		


### PR DESCRIPTION
This is useful for correlating crash dumps between machines, where Visual Studio [Code] refuses to load debugging symbols for files with different timestamps.  Need to know what those timestamps are :)