### PR TITLE
make the parsing of ThreadContext optional

### DIFF
--- a/minidump/minidumpfile.py
+++ b/minidump/minidumpfile.py
@@ -210,7 +210,7 @@ class MinidumpFile:
 			logging.exception('Thread context parsing error!')
 
 	def __parse_thread_context(self):
-		if not self.sysinfo:
+		if not self.sysinfo or not self.threads:
 			return
 		for thread in self.threads.threads:
 			rva = thread.ThreadContext.Rva


### PR DESCRIPTION
This information is typically not included in LSASS minidumps made programmatically