### PR TITLE
Case insensitive module search

### DIFF
--- a/minidump/aminidumpreader.py
+++ b/minidump/aminidumpreader.py
@@ -308,7 +308,7 @@ class AMinidumpFileReader:
 
 	def get_module_by_name(self, module_name):
 		for mod in self.modules:
-			if ntpath.basename(mod.name).find(module_name) != -1:
+			if ntpath.basename(mod.name.lower()).find(module_name.lower()) != -1:
 				return mod
 		return None
 

--- a/minidump/aminidumpreader.py
+++ b/minidump/aminidumpreader.py
@@ -308,7 +308,7 @@ class AMinidumpFileReader:
 
 	def get_module_by_name(self, module_name):
 		for mod in self.modules:
-			if ntpath.basename(mod.name).lower() == module_name.lower():
+			if ntpath.basename(mod.name).lower().find(module_name.lower()) != -1:
 				return mod
 		return None
 

--- a/minidump/aminidumpreader.py
+++ b/minidump/aminidumpreader.py
@@ -308,7 +308,7 @@ class AMinidumpFileReader:
 
 	def get_module_by_name(self, module_name):
 		for mod in self.modules:
-			if ntpath.basename(mod.name.lower()).find(module_name.lower()) != -1:
+			if ntpath.basename(mod.name).lower() == module_name.lower():
 				return mod
 		return None
 

--- a/minidump/minidumpfile.py
+++ b/minidump/minidumpfile.py
@@ -210,7 +210,7 @@ class MinidumpFile:
 			logging.exception('Thread context parsing error!')
 
 	def __parse_thread_context(self):
-		if not self.sysinfo:
+		if not self.sysinfo or not self.threads:
 			return
 		for thread in self.threads.threads:
 			rva = thread.ThreadContext.Rva

--- a/minidump/minidumpreader.py
+++ b/minidump/minidumpreader.py
@@ -319,7 +319,7 @@ class MinidumpFileReader:
 
 	def get_module_by_name(self, module_name):
 		for mod in self.modules:
-			if ntpath.basename(mod.name).find(module_name) != -1:
+			if ntpath.basename(mod.name.lower()).find(module_name.lower()) != -1:
 				return mod
 		return None
 

--- a/minidump/minidumpreader.py
+++ b/minidump/minidumpreader.py
@@ -319,7 +319,7 @@ class MinidumpFileReader:
 
 	def get_module_by_name(self, module_name):
 		for mod in self.modules:
-			if ntpath.basename(mod.name).lower() == module_name.lower():
+			if ntpath.basename(mod.name).lower().find(module_name.lower()) != -1:
 				return mod
 		return None
 

--- a/minidump/minidumpreader.py
+++ b/minidump/minidumpreader.py
@@ -319,7 +319,7 @@ class MinidumpFileReader:
 
 	def get_module_by_name(self, module_name):
 		for mod in self.modules:
-			if ntpath.basename(mod.name.lower()).find(module_name.lower()) != -1:
+			if ntpath.basename(mod.name).lower() == module_name.lower():
 				return mod
 		return None
 


### PR DESCRIPTION
Some DLLs have very weird capitalization (for example: `cloudAP.DLL`), this small change fixes those cases in which minidump doesn't find a module that is actually included in the dump file.

Note: this PR lies on top of [this one](https://github.com/skelsec/minidump/pull/26)