### PR TITLE
Fix off-by-one error in bounds checks

### DIFF
--- a/minidump/aminidumpreader.py
+++ b/minidump/aminidumpreader.py
@@ -30,7 +30,7 @@ class AMinidumpBufferedMemorySegment:
 		self.chunks = []
 
 	def inrange(self, position):
-		return self.start_address <= position <= self.end_address
+		return self.start_address <= position < self.end_address
 
 	def remaining_len(self, position):
 		if not self.inrange(position):

--- a/minidump/minidumpreader.py
+++ b/minidump/minidumpreader.py
@@ -31,7 +31,7 @@ class MinidumpBufferedMemorySegment:
 		self.chunks = []
 
 	def inrange(self, position):
-		return self.start_address <= position <= self.end_address
+		return self.start_address <= position < self.end_address
 
 	def remaining_len(self, position):
 		if not self.inrange(position):
@@ -183,7 +183,7 @@ class MinidumpBufferedReader:
 			return self.current_segment.read(self.reader.file_handle, old_new_pos - self.current_segment.start_address, None)
 
 		t = self.current_position + size
-		if not self.current_segment.inrange(t):
+		if not self.current_segment.inrange(t - 1):
 			raise Exception('Would read over segment boundaries!')
 
 		old_new_pos = self.current_position


### PR DESCRIPTION
Code snippet to reproduce the bug:

```python
seg: MinidumpMemorySegment
        for seg in self._minidump.memory_segments_64.memory_segments:
            print(f"initialize base: 0x{seg.start_virtual_address:x}, size: 0x{seg.size:x}")
            self._memory.move(seg.start_virtual_address)
            assert self._memory.current_position == seg.start_virtual_address
            data = self._memory.read(seg.size)
```

The bounds check first moves the position and then checks if it's in bounds, but this is incorrect because if you read the full page it would look like things are out of bounds even though they aren't.