### PR TITLE
Add basic support for writing minidumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+*.exe
+*.DMP
+*.dmp

--- a/minidump/common_structs.py
+++ b/minidump/common_structs.py
@@ -1,7 +1,7 @@
 
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms680383(v=vs.85).aspx	
 class MINIDUMP_LOCATION_DESCRIPTOR:
-	def __init__(self, DataSize = None, Rva = None):
+	def __init__(self, DataSize = 0, Rva = 0):
 		self.DataSize = DataSize
 		self.Rva = Rva
 
@@ -26,8 +26,8 @@ class MINIDUMP_LOCATION_DESCRIPTOR:
 		
 class MINIDUMP_LOCATION_DESCRIPTOR64:
 	def __init__(self):
-		self.DataSize = None
-		self.Rva = None
+		self.DataSize = 0
+		self.Rva = 0
 
 	def get_size(self):
 		return 16

--- a/minidump/common_structs.py
+++ b/minidump/common_structs.py
@@ -63,8 +63,8 @@ class MINIDUMP_STRING:
 		self.Buffer = None
 		self.encoding = encoding
 		if data is not None:
-			self.Buffer = data.encode(self.encoding)
-			self.Length = len(self.Buffer)
+			self.Buffer = data.encode(self.encoding) + b"\x00\x00"
+			self.Length = len(self.Buffer) + 2
 
 	
 	def to_bytes(self):

--- a/minidump/common_structs.py
+++ b/minidump/common_structs.py
@@ -56,6 +56,7 @@ class MINIDUMP_STRING:
 		if data is not None:
 			self.Buffer = data.encode(self.encoding)
 			self.Length = len(self.Buffer)
+
 	
 	def to_bytes(self):
 		t = self.Length.to_bytes(4, byteorder = 'little', signed = False)

--- a/minidump/directory.py
+++ b/minidump/directory.py
@@ -7,6 +7,12 @@ class MINIDUMP_DIRECTORY:
 		self.StreamType = None
 		self.Location = None
 
+	def to_buffer(self, buffer):
+		"""
+		Locaton must be set for the correct location in the databuffer!
+		"""
+		buffer.write(self.to_bytes())
+
 	def to_bytes(self):
 		t = self.StreamType.value.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.Location.to_bytes()

--- a/minidump/header.py
+++ b/minidump/header.py
@@ -21,9 +21,8 @@ class MinidumpHeader:
 		t += self.NumberOfStreams.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.StreamDirectoryRva.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.CheckSum.to_bytes(4, byteorder = 'little', signed = False)
-		t += self.Reserved.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.TimeDateStamp.to_bytes(4, byteorder = 'little', signed = False)
-		t += self.Flags.value.to_bytes(4, byteorder = 'little', signed = False)
+		t += self.Flags.value.to_bytes(8, byteorder = 'little', signed = False)
 
 		return t
 
@@ -38,10 +37,9 @@ class MinidumpHeader:
 		mh.NumberOfStreams = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mh.StreamDirectoryRva = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mh.CheckSum = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
-		mh.Reserved = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mh.TimeDateStamp = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		try:
-			mh.Flags = MINIDUMP_TYPE(int.from_bytes(buff.read(4), byteorder = 'little', signed = False))
+			mh.Flags = MINIDUMP_TYPE(int.from_bytes(buff.read(8), byteorder = 'little', signed = False))
 		except Exception as e:
 			raise MinidumpHeaderFlagsException('Could not parse header flags!')
 
@@ -55,7 +53,6 @@ class MinidumpHeader:
 		t+= 'NumberOfStreams: %s\n' % self.NumberOfStreams
 		t+= 'StreamDirectoryRva: %s\n' % self.StreamDirectoryRva
 		t+= 'CheckSum: %s\n' % self.CheckSum
-		t+= 'Reserved: %s\n' % self.Reserved
 		t+= 'TimeDateStamp: %s\n' % self.TimeDateStamp
 		t+= 'Flags: %s\n' % self.Flags
 		return t

--- a/minidump/header.py
+++ b/minidump/header.py
@@ -14,6 +14,12 @@ class MinidumpHeader:
 		self.TimeDateStamp = 0
 		self.Flags = None
 
+	def to_buffer(self, buffer):
+		self.StreamDirectoryRva = buffer.tell() + 16 # stream directory starts right after the end of the header
+		buffer.write(self.to_bytes())
+		# no need to seek here, the directories will be serialized by the file object
+
+
 	def to_bytes(self):
 		t = self.Signature.encode('ascii')
 		t += self.Version.to_bytes(2, byteorder = 'little', signed = False)

--- a/minidump/header.py
+++ b/minidump/header.py
@@ -4,7 +4,7 @@ from minidump.exceptions import MinidumpHeaderFlagsException, MinidumpHeaderSign
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms680378(v=vs.85).aspx
 class MinidumpHeader:
 	def __init__(self):
-		self.Signature = 'PMDM'
+		self.Signature = 'MDMP'
 		self.Version = None
 		self.ImplementationVersion = None
 		self.NumberOfStreams = None
@@ -13,12 +13,6 @@ class MinidumpHeader:
 		self.Reserved = 0
 		self.TimeDateStamp = 0
 		self.Flags = None
-
-	def to_buffer(self, buffer):
-		self.StreamDirectoryRva = buffer.tell() + 16 # stream directory starts right after the end of the header
-		buffer.write(self.to_bytes())
-		# no need to seek here, the directories will be serialized by the file object
-
 
 	def to_bytes(self):
 		t = self.Signature.encode('ascii')

--- a/minidump/minidumpfile.py
+++ b/minidump/minidumpfile.py
@@ -55,7 +55,7 @@ class MinidumpFile:
 		self.header.Version = 42899
 		self.header.ImplementationVersion = 41146
 		self.header.NumberOfStreams = len(self.writer.get_available_directories())
-		self.header.Flags = MINIDUMP_TYPE.MiniDumpNormal
+		self.header.Flags = 2
 		self.header.StreamDirectoryRva = buffer.tell() + 32
 		
 		hdr_bytes = self.header.to_bytes()
@@ -65,7 +65,6 @@ class MinidumpFile:
 			databuffer.write(b'\x00' * 12)
 		
 		databuff_trim = databuffer.tell()
-		input(hex(databuff_trim))
 		offset = databuff_trim
 		for directory in self.writer.get_available_directories():
 			directory.Location = MINIDUMP_LOCATION_DESCRIPTOR()

--- a/minidump/minidumpfile.py
+++ b/minidump/minidumpfile.py
@@ -15,7 +15,7 @@ from minidump.minidumpreader import MinidumpFileReader
 from minidump.streams import *
 from minidump.common_structs import *
 from minidump.constants import MINIDUMP_STREAM_TYPE
-from minidump.directory import MINIDUMP_DIRECTORY
+from minidump.directory import MINIDUMP_DIRECTORY, DirectoryBuffer
 from minidump.constants import MINIDUMP_TYPE
 
 class MinidumpFile:
@@ -52,47 +52,84 @@ class MinidumpFile:
 		mem_present = False
 
 		self.header = MinidumpHeader()
-		self.header.Version = 1
-		self.header.ImplementationVersion = 1
-		self.header.NumberOfStreams = len([self.writer.get_available_directories])
-		self.header.Flags = MINIDUMP_TYPE.MiniDumpWithFullMemory
+		self.header.Version = 42899
+		self.header.ImplementationVersion = 41146
+		self.header.NumberOfStreams = len(self.writer.get_available_directories())
+		self.header.Flags = MINIDUMP_TYPE.MiniDumpNormal
+		self.header.StreamDirectoryRva = buffer.tell() + 32
 		
 		hdr_bytes = self.header.to_bytes()
 		buffer.write(hdr_bytes)
 		databuffer.write(b'\x00' * len(hdr_bytes))
-		for directory in self.writer.get_available_directories:
-			databuffer.write(b'\x00' * 8)
+		for directory in self.writer.get_available_directories():
+			databuffer.write(b'\x00' * 12)
 		
-		for directory in self.writer.get_available_directories:
-			directory.Location = databuffer.tell()
+		databuff_trim = databuffer.tell()
+		input(hex(databuff_trim))
+		offset = databuff_trim
+		for directory in self.writer.get_available_directories():
+			directory.Location = MINIDUMP_LOCATION_DESCRIPTOR()
+			directory.Location.Rva = databuffer.tell()
+			db = DirectoryBuffer(offset = offset)
 			if directory.StreamType == MINIDUMP_STREAM_TYPE.SystemInfoStream:
-				self.writer.get_sysinfo(databuffer)
+				self.writer.get_sysinfo(db)
 			elif directory.StreamType == MINIDUMP_STREAM_TYPE.ModuleListStream:
-				self.writer.get_modules(databuffer)
+				self.writer.get_modules(db)
 			elif directory.StreamType == MINIDUMP_STREAM_TYPE.MemoryInfoListStream:
-				self.writer.get_sections(databuffer)
+				self.writer.get_sections(db)
+			elif directory.StreamType == MINIDUMP_STREAM_TYPE.UnloadedModuleListStream:
+				self.writer.get_unloaded_modules(db)
+			elif directory.StreamType == MINIDUMP_STREAM_TYPE.HandleDataStream:
+				self.writer.get_handle_data(db)
+			elif directory.StreamType == MINIDUMP_STREAM_TYPE.ThreadInfoListStream:
+				self.writer.get_threadinfo(db)
+			elif directory.StreamType == MINIDUMP_STREAM_TYPE.ThreadListStream:
+				self.writer.get_threads(db)
 			elif directory.StreamType == MINIDUMP_STREAM_TYPE.Memory64ListStream:
 				mem64_present = True
 				continue #skipping this!
 			elif directory.StreamType == MINIDUMP_STREAM_TYPE.MemoryListStream:
 				mem_present = True
 				continue #skipping this!
-
+			#else:
+			#	#raise Exception('Unknown directory type here!')
+			
+			buffsize = db.buffer.tell()
+			databuffer.write(db.finalize())
+			#directory.Location.DataSize = 
+			directory.Location.DataSize = buffsize
+			offset += databuffer.tell() - directory.Location.Rva
+			#input(hex(directory.Location.DataSize))
 			directory.to_buffer(buffer)
 
 		if mem64_present is True:
 			# if memory is present, we add one more directory entry to the directory list, and finalize the header
+			end_pos = buffer.tell() #this is stored to update the actual size of the memory stream after dumping!
+
 			memdir = MINIDUMP_DIRECTORY()
-			memdir.Location = databuffer.tell()
+			memdir.Location = MINIDUMP_LOCATION_DESCRIPTOR() 
+			memdir.Location.Rva = databuffer.tell()
 			memdir.StreamType = MINIDUMP_STREAM_TYPE.Memory64ListStream
+			memdir.Location.DataSize = 0 #marking it as zero now. will need to update this later! #databuffer.tell() - directory.Location.Rva
 			memdir.to_buffer(buffer)
-			databuffer.seek(0,0)
+
+			
+			
+			databuffer.seek(databuff_trim,0)
 			buffer.write(databuffer.read())
-			self.writer.get_memory(buffer) # here we use the merged buffer (or the actual file) because memory to dump might be huge
+			datasize = self.writer.get_memory(buffer) # here we use the merged buffer (or the actual file) because memory to dump might be huge
+			
+			buffer.seek(end_pos + 4) #skipping the type
+			buffer.write(datasize.to_bytes(4, byteorder = 'little', signed = False))
+
+			print(datasize)
 			return
+			
+			
 
 		elif mem_present is True:
 			raise Exception('Not yet implemented!')
+			
 
 	@staticmethod
 	def parse(filename):
@@ -130,6 +167,7 @@ class MinidumpFile:
 
 	def _parse(self):
 		self.__parse_header()
+		print(self.header)
 		self.__parse_directories()
 
 	def __parse_header(self):
@@ -146,8 +184,9 @@ class MinidumpFile:
 				logging.debug('Found Unknown UserStream directory Type: %x' % (user_stream_type_value))
 
 	def __parse_directories(self):
-
+		
 		for dir in self.directories:
+			#print(dir.StreamType)
 			if dir.StreamType == MINIDUMP_STREAM_TYPE.UnusedStream:
 				logging.debug('Found UnusedStream @%x Size: %d' % (dir.Location.Rva, dir.Location.DataSize))
 				continue # Reserved. Do not use this enumeration value.

--- a/minidump/streams/HandleDataStream.py
+++ b/minidump/streams/HandleDataStream.py
@@ -10,11 +10,17 @@ from minidump.common_structs import *
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms680372(v=vs.85).aspx
 class MINIDUMP_HANDLE_DATA_STREAM:
 	def __init__(self):
-		self.SizeOfHeader = None
-		self.SizeOfDescriptor = None
+		self.SizeOfHeader = 16
+		self.SizeOfDescriptor = 40
 		self.NumberOfDescriptors = None
-		self.Reserved = None
+		self.Reserved = 0
 	
+	def to_buffer(self, buffer):
+		buffer.write(self.SizeOfHeader.to_bytes(4, byteorder = 'little', signed = False))
+		buffer.write(self.SizeOfDescriptor.to_bytes(4, byteorder = 'little', signed = False))
+		buffer.write(self.NumberOfDescriptors.to_bytes(4, byteorder = 'little', signed = False))
+		buffer.write(self.Reserved.to_bytes(4, byteorder = 'little', signed = False))
+
 	@staticmethod
 	def parse(buff):
 		mhds = MINIDUMP_HANDLE_DATA_STREAM()
@@ -22,6 +28,11 @@ class MINIDUMP_HANDLE_DATA_STREAM:
 		mhds.SizeOfDescriptor = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mhds.NumberOfDescriptors = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mhds.Reserved = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
+		#print(mhds.SizeOfHeader)
+		#print(mhds.SizeOfDescriptor)
+		#print(mhds.NumberOfDescriptors)
+		#print(mhds.Reserved)
+		#print()
 			
 		return mhds
 	

--- a/minidump/streams/Memory64ListStream.py
+++ b/minidump/streams/Memory64ListStream.py
@@ -13,15 +13,11 @@ class MINIDUMP_MEMORY64_LIST:
 		self.BaseRva = None
 		self.MemoryRanges = []
 
-	def get_size(self):
-		return 8 + 8 + len(self.MemoryRanges) * MINIDUMP_MEMORY_DESCRIPTOR64().get_size()
-
-	def to_bytes(self):
-		t = len(self.MemoryRanges).to_bytes(8, byteorder = 'little', signed = False)
-		t += self.BaseRva.to_bytes(8, byteorder = 'little', signed = False)
+	def to_buffer(self, buffer):
+		buffer.write(len(self.MemoryRanges).to_bytes(8, byteorder = 'little', signed = False))
+		buffer.write(self.BaseRva.to_bytes(8, byteorder = 'little', signed = False))
 		for memrange in self.MemoryRanges:
-			t += memrange.to_bytes()
-		return t
+			memrange.to_buffer(buffer)
 	
 	@staticmethod
 	def parse(buff):
@@ -48,13 +44,9 @@ class MINIDUMP_MEMORY_DESCRIPTOR64:
 		self.StartOfMemoryRange = None
 		self.DataSize = None
 
-	def get_size(self):
-		return 16
-
-	def to_bytes(self):
-		t = self.StartOfMemoryRange.to_bytes(8, byteorder = 'little', signed = False)
-		t += self.DataSize.to_bytes(8, byteorder = 'little', signed = False)
-		return t
+	def to_buffer(self, buffer):
+		buffer.write(self.StartOfMemoryRange.to_bytes(8, byteorder = 'little', signed = False))
+		buffer.write(self.DataSize.to_bytes(8, byteorder = 'little', signed = False))
 		
 	@staticmethod
 	def parse(buff):

--- a/minidump/streams/MemoryInfoListStream.py
+++ b/minidump/streams/MemoryInfoListStream.py
@@ -8,7 +8,6 @@ import enum
 from minidump.common_structs import * 
 
 class AllocationProtect(enum.Enum):
-	NONE = 0
 	PAGE_EXECUTE = 0x10 #Enables execute access to the committed region of pages. An attempt to write to the committed region results in an access violation.
 						#This flag is not supported by the CreateFileMapping function.
 
@@ -123,9 +122,18 @@ class MINIDUMP_MEMORY_INFO:
 		t += self.AllocationProtect.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.__alignment1.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.RegionSize.to_bytes(8, byteorder = 'little', signed = False)
-		t += self.State.value.to_bytes(4, byteorder = 'little', signed = False)
-		t += self.Protect.value.to_bytes(4, byteorder = 'little', signed = False)
-		t += self.Type.value.to_bytes(4, byteorder = 'little', signed = False)
+		if isinstance(self.State, int):
+			t += self.State.to_bytes(4, byteorder = 'little', signed = False)
+		else:
+			t += self.State.value.to_bytes(4, byteorder = 'little', signed = False)
+		if isinstance(self.Protect, int):
+			t += self.Protect.to_bytes(4, byteorder = 'little', signed = False)
+		else:
+			t += self.Protect.value.to_bytes(4, byteorder = 'little', signed = False)
+		if isinstance(self.Type, int):
+			t += self.Type.to_bytes(4, byteorder = 'little', signed = False)
+		else:
+			t += self.Type.value.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.__alignment2.to_bytes(4, byteorder = 'little', signed = False)
 		return t
 	

--- a/minidump/streams/MemoryInfoListStream.py
+++ b/minidump/streams/MemoryInfoListStream.py
@@ -70,6 +70,13 @@ class MINIDUMP_MEMORY_INFO_LIST:
 		self.NumberOfEntries = None
 		self.entries = []
 
+	def to_buffer(self, buffer):
+		buffer.write(self.SizeOfHeader.to_bytes(4, byteorder = 'little', signed = False))
+		buffer.write(self.SizeOfEntry.to_bytes(4, byteorder = 'little', signed = False))
+		buffer.write(len(self.entries).to_bytes(8, byteorder = 'little', signed = False))
+		for ent in self.entries:
+			buffer.write(ent.to_bytes())
+
 	def get_size(self):
 		return self.SizeOfHeader + len(self.entries)*MINIDUMP_MEMORY_INFO().get_size()
 

--- a/minidump/streams/MemoryListStream.py
+++ b/minidump/streams/MemoryListStream.py
@@ -39,13 +39,16 @@ class MINIDUMP_MEMORY_DESCRIPTOR:
 	def __init__(self):
 		self.StartOfMemoryRange = None
 		self.MemoryLocation = None
-		
+		self.StartOfMemoryRange = 0
+		self.MemoryLocation = MINIDUMP_LOCATION_DESCRIPTOR()
+
 		#we do not use MemoryLocation but immediately store its fields in this object for easy access
-		self.DataSize = None
-		self.Rva = None
+		self.DataSize = 0
+		self.Rva = 0
 
 	def to_bytes(self):
-		t = self.StartOfMemoryRange.to_bytes(4, byteorder = 'little', signed = False)
+		t = self.StartOfMemoryRange.to_bytes(8, byteorder = 'little', signed = False)
+		self.MemoryLocation = MINIDUMP_LOCATION_DESCRIPTOR(self.DataSize, self.Rva)
 		t += self.MemoryLocation.to_bytes()
 		return t
 		

--- a/minidump/streams/SystemInfoStream.py
+++ b/minidump/streams/SystemInfoStream.py
@@ -112,9 +112,9 @@ class MINIDUMP_SYSTEM_INFO:
 		if self.ProcessorArchitecture == PROCESSOR_ARCHITECTURE.INTEL:
 			for vid in self.VendorId:
 				buffer.write(vid.to_bytes(4, byteorder = 'little', signed = False))
-			buffer.write(self.VersionInformation.value.to_bytes(4, byteorder = 'little', signed = False))
-			buffer.write(self.FeatureInformation.value.to_bytes(4, byteorder = 'little', signed = False))
-			buffer.write(self.AMDExtendedCpuFeatures.value.to_bytes(4, byteorder = 'little', signed = False))
+			buffer.write(self.VersionInformation.to_bytes(4, byteorder = 'little', signed = False))
+			buffer.write(self.FeatureInformation.to_bytes(4, byteorder = 'little', signed = False))
+			buffer.write(self.AMDExtendedCpuFeatures.to_bytes(4, byteorder = 'little', signed = False))
 		else:
 			for pf in self.ProcessorFeatures:
 				buffer.write(pf.to_bytes(8, byteorder = 'little', signed = False))

--- a/minidump/streams/SystemInfoStream.py
+++ b/minidump/streams/SystemInfoStream.py
@@ -120,10 +120,6 @@ class MINIDUMP_SYSTEM_INFO:
 			for pf in self.ProcessorFeatures:
 				t += pf.to_bytes(8, byteorder = 'little', signed = False)
 
-		if data_buffer is None:
-			return t
-		else:
-			data_buffer.write(t)
 
 	@staticmethod
 	def parse(buff):

--- a/minidump/streams/ThreadInfoListStream.py
+++ b/minidump/streams/ThreadInfoListStream.py
@@ -19,15 +19,14 @@ class DumpFlags(enum.Enum):
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms680506(v=vs.85).aspx
 class MINIDUMP_THREAD_INFO_LIST:
 	def __init__(self):
-		self.SizeOfHeader = None
-		self.SizeOfEntry = None
+		self.SizeOfHeader = 12
+		self.SizeOfEntry = 64
 		self.NumberOfEntries = None
 	
-	def to_bytes(self):
-		t = self.SizeOfHeader.value.to_bytes(4, byteorder = 'little', signed = False)
-		t += self.SizeOfEntry.to_bytes(4, byteorder = 'little', signed = False)
-		t += self.NumberOfEntries.to_bytes(4, byteorder = 'little', signed = False)
-		return t
+	def to_buffer(self, buffer):
+		buffer.write(self.SizeOfHeader.to_bytes(4, byteorder = 'little', signed = False))
+		buffer.write(self.SizeOfEntry.to_bytes(4, byteorder = 'little', signed = False))
+		buffer.write(self.NumberOfEntries.to_bytes(4, byteorder = 'little', signed = False))
 
 	@staticmethod
 	def parse(buff):
@@ -35,7 +34,6 @@ class MINIDUMP_THREAD_INFO_LIST:
 		mtil.SizeOfHeader = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mtil.SizeOfEntry = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mtil.NumberOfEntries = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
-		
 		return mtil
 		
 	

--- a/minidump/streams/ThreadListStream.py
+++ b/minidump/streams/ThreadListStream.py
@@ -13,11 +13,10 @@ class MINIDUMP_THREAD_LIST:
 		self.NumberOfThreads = None
 		self.Threads = []
 
-	def to_bytes(self):
-		t = len(self.Threads).to_bytes(4, byteorder = 'little', signed = False)
+	def to_buffer(self, buffer):
+		buffer.write(len(self.Threads).to_bytes(4, byteorder = 'little', signed = False))
 		for th in self.Threads:
-			t += th.to_bytes()
-		return t
+			th.to_buffer(buffer)
 	
 	@staticmethod
 	def parse(buff):

--- a/minidump/streams/ThreadListStream.py
+++ b/minidump/streams/ThreadListStream.py
@@ -34,11 +34,11 @@ class MINIDUMP_THREAD:
 		self.PriorityClass = None
 		self.Priority = None
 		self.Teb = None
-		self.Stack = None
-		self.ThreadContext = None
+		self.Stack = MINIDUMP_MEMORY_DESCRIPTOR()
+		self.ThreadContext = MINIDUMP_LOCATION_DESCRIPTOR()
 
 	def to_bytes(self):
-		t  = self.ThreadId.value.to_bytes(4, byteorder = 'little', signed = False)
+		t  = self.ThreadId.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.SuspendCount.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.PriorityClass.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.Priority.to_bytes(4, byteorder = 'little', signed = False)
@@ -47,6 +47,9 @@ class MINIDUMP_THREAD:
 		t += self.ThreadContext.to_bytes()
 		return t
 	
+	def to_buffer(self, buffer):
+		buffer.write(self.to_bytes())
+
 	@staticmethod
 	def parse(buff):
 		mt = MINIDUMP_THREAD()

--- a/minidump/streams/UnloadedModuleListStream.py
+++ b/minidump/streams/UnloadedModuleListStream.py
@@ -10,15 +10,14 @@ from minidump.common_structs import *
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms680521(v=vs.85).aspx
 class MINIDUMP_UNLOADED_MODULE_LIST:
 	def __init__(self):
-		self.SizeOfHeader = None
-		self.SizeOfEntry = None
+		self.SizeOfHeader = 12
+		self.SizeOfEntry = 24
 		self.NumberOfEntries = None
 
-	def to_bytes(self):
-		t  = self.SizeOfHeader.value.to_bytes(4, byteorder = 'little', signed = False)
-		t += self.SizeOfEntry.to_bytes(4, byteorder = 'little', signed = False)
-		t += self.NumberOfEntries.to_bytes(4, byteorder = 'little', signed = False)
-		return t
+	def to_buffer(self, buffer):
+		buffer.write(self.SizeOfHeader.to_bytes(4, byteorder = 'little', signed = False))
+		buffer.write(self.SizeOfEntry.to_bytes(4, byteorder = 'little', signed = False))
+		buffer.write(self.NumberOfEntries.to_bytes(4, byteorder = 'little', signed = False))
 	
 	@staticmethod
 	def parse(buff):

--- a/minidump/utils/winapi/version.py
+++ b/minidump/utils/winapi/version.py
@@ -109,4 +109,5 @@ def GetFileVersionInfoW(lptstrFilename):
     dwLen = _GetFileVersionInfoSizeW(lptstrFilename, None)
     lpData = ctypes.create_string_buffer(dwLen)  # not a string!
     _GetFileVersionInfoW(lptstrFilename, 0, dwLen, byref(lpData))
+    
     return lpData

--- a/minidump/writer.py
+++ b/minidump/writer.py
@@ -1,9 +1,10 @@
 from minidump.constants import MINIDUMP_STREAM_TYPE, MINIDUMP_TYPE
 from minidump.header import MinidumpHeader
 from minidump.common_structs import MINIDUMP_LOCATION_DESCRIPTOR
+from minidump.utils.privileges import enable_debug_privilege
 
 from minidump.utils.winapi.version import GetSystemInfo, GetVersionExW
-from minidump.utils.winapi.kernel32 import OpenProcess, PROCESS_ALL_ACCESS, VirtualQueryEx, ReadProcessMemory
+from minidump.utils.winapi.kernel32 import OpenProcess, PROCESS_ALL_ACCESS, VirtualQueryEx, ReadProcessMemory, CreateToolhelp32Snapshot, Thread32First, Thread32Next
 from minidump.utils.winapi.psapi import EnumProcessModules, GetModuleInformation, GetModuleFileNameExW
 from minidump.utils.winapi.version import GetFileVersionInfoW
 from minidump.streams import MINIDUMP_SYSTEM_INFO, PROCESSOR_ARCHITECTURE, MINIDUMP_MODULE_LIST, \
@@ -12,10 +13,15 @@ from minidump.streams import MINIDUMP_SYSTEM_INFO, PROCESSOR_ARCHITECTURE, MINID
 	MINIDUMP_MEMORY64_LIST, MINIDUMP_MEMORY_DESCRIPTOR64
 
 from minidump.streams.SystemInfoStream import PROCESSOR_ARCHITECTURE, PRODUCT_TYPE
+from minidump.streams.UnloadedModuleListStream import MINIDUMP_UNLOADED_MODULE_LIST
+from minidump.streams.HandleDataStream import MINIDUMP_HANDLE_DATA_STREAM
+from minidump.streams.ThreadInfoListStream import MINIDUMP_THREAD_INFO_LIST
+from minidump.streams.ThreadListStream import MINIDUMP_THREAD_LIST
 
 from minidump.directory import MINIDUMP_DIRECTORY
 
 import io
+		
 
 class MinidumpSystemReader:
 	def __init__(self):
@@ -47,23 +53,41 @@ class LiveSystemReader(MinidumpSystemReader):
 		MinidumpSystemReader.__init__(self)
 		self.pid = pid
 		self.process_handle = None
+		self.process_toolhelp_handle = None
 		self.sysinfo = None
 		self.meminfolist = None
-		self.streamtypes = [MINIDUMP_STREAM_TYPE.SystemInfoStream, MINIDUMP_STREAM_TYPE.ModuleListStream, MINIDUMP_STREAM_TYPE.MemoryInfoListStream, MINIDUMP_STREAM_TYPE.Memory64ListStream]
+		self.streamtypes = [
+			MINIDUMP_STREAM_TYPE.SystemInfoStream, 
+			MINIDUMP_STREAM_TYPE.ModuleListStream, 
+			MINIDUMP_STREAM_TYPE.MemoryInfoListStream, 
+			MINIDUMP_STREAM_TYPE.Memory64ListStream,
+			MINIDUMP_STREAM_TYPE.UnloadedModuleListStream,
+			MINIDUMP_STREAM_TYPE.HandleDataStream,
+			MINIDUMP_STREAM_TYPE.ThreadInfoListStream,
+			#MINIDUMP_STREAM_TYPE.SystemMemoryInfoStream,
+			MINIDUMP_STREAM_TYPE.ThreadListStream,
+			
+		]
 		self.setup()
 
 	def get_available_directories(self):
+		sts = []
 		for st in self.streamtypes:
 			memdir = MINIDUMP_DIRECTORY()
-			memdir.Location = 0 #location is not needed, only the type
+			memdir.Location = None #location is not needed, only the type
 			memdir.StreamType = st
-			yield memdir
+			sts.append(memdir)
+		return sts
 
 	def open_process(self):
 		self.process_handle = OpenProcess(PROCESS_ALL_ACCESS, False, self.pid)
 
+	def open_toolhelp(self):
+		self.process_toolhelp_handle = CreateToolhelp32Snapshot(th32ProcessID = self.pid)
+
 	def setup(self):
 		self.open_process()
+		self.open_toolhelp()
 
 	def get_sysinfo(self, databuffer):
 		#https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsysteminfo
@@ -86,7 +110,7 @@ class LiveSystemReader(MinidumpSystemReader):
 		sysinfo.SuiteMask = version_raw.wSuiteMask
 		#sysinfo.Reserved2 = None
 
-		sysinfo.CSDVersion = version_raw.szCSDVersion
+		sysinfo.CSDVersion = None #version_raw.szCSDVersion
 
 		#below todo, keeping all zeroes for now..
 		if sysinfo.ProcessorArchitecture == PROCESSOR_ARCHITECTURE.INTEL:
@@ -98,9 +122,26 @@ class LiveSystemReader(MinidumpSystemReader):
 			sysinfo.ProcessorFeatures = [0,0]
 		
 		self.sysinfo_raw = sysinfo_raw #other functions will be using data from sysinfo so we need to store it!
+		#p1 = databuffer.tell()
 		sysinfo.to_buffer(databuffer)
-		
+		#input('Sysinfo size: %s' % (databuffer.tell() - p1))
+	
+	def get_threadinfo(self, databuffer):
+		ti = MINIDUMP_THREAD_INFO_LIST()
+		ti.NumberOfEntries = 0
+		ti.to_buffer(databuffer)
 
+	def get_handle_data(self, databuffer):
+		hds = MINIDUMP_HANDLE_DATA_STREAM()
+		hds.NumberOfDescriptors = 0
+		hds.to_buffer(databuffer)
+
+	def get_unloaded_modules(self, databuffer):
+		#TODO: implement this. problem: finding an api call that differentiates between loaded and unloaded modules
+		# currently returning empty list
+		umodlist = MINIDUMP_UNLOADED_MODULE_LIST()
+		umodlist.NumberOfEntries = 0
+		umodlist.to_buffer(databuffer)
 
 	def get_modules(self, databuffer):
 		#https://docs.microsoft.com/en-us/windows/win32/psapi/enumerating-all-modules-for-a-process
@@ -108,20 +149,27 @@ class LiveSystemReader(MinidumpSystemReader):
 		#
 		module_list = MINIDUMP_MODULE_LIST()
 		for module in EnumProcessModules(self.process_handle):
-			print(module)
+			#print(module)
 			modinfo = GetModuleInformation(self.process_handle,module)
 			modname = GetModuleFileNameExW(self.process_handle,module)
-			fileversion_raw = GetFileVersionInfoW(modname)
-			fileversion = VS_FIXEDFILEINFO.from_bytes(fileversion_raw)
-			print(modname)
+			#print(modname)
+			try:
+				fileversion_raw = GetFileVersionInfoW(modname)
+				fileversion = VS_FIXEDFILEINFO.from_bytes(fileversion_raw.raw[8+(16*2):])
+				ts = fileversion.dwFileDateMS << 32 + fileversion.dwFileDateLS
+			except Exception as e:
+				print("Failed to get fileversion! Reason: %s " % e)
+				fileversion = None
+				ts = 0
+			
 			mmod = MINIDUMP_MODULE()
 			mmod.BaseOfImage = modinfo.lpBaseOfDll
 			mmod.SizeOfImage = modinfo.SizeOfImage
-			mmod.TimeDateStamp = fileversion.dwFileDateMS << 32 + fileversion.dwFileDateLS
+			mmod.TimeDateStamp = ts
 			mmod.ModuleNameRva = None
 			mmod.VersionInfo = fileversion
-			mmod.CvRecord = 0 # TODO?
-			mmod.MiscRecord = 0 # TODO?
+			mmod.CvRecord = None # TODO?
+			mmod.MiscRecord = None # TODO?
 
 			mmod.ModuleName = modname
 
@@ -161,12 +209,28 @@ class LiveSystemReader(MinidumpSystemReader):
 		meminfolist.to_buffer(databuffer)
 	
 	def get_threads(self, databuffer):
-		pass
+		tl = MINIDUMP_THREAD_LIST()
+		tl.to_buffer(databuffer)
+
+		#te = Thread32First(self.process_toolhelp_handle)
+		#while te is not None:
+		#	dwThreadId = te.th32ThreadID
+		#	te = Thread32Next(process_toolhelp_handle)
+#
+#
+		#	('dwSize',             DWORD),
+        #('cntUsage',           DWORD),
+        #('th32ThreadID',       DWORD),
+        #('th32OwnerProcessID', DWORD),
+        #('tpBasePri',          LONG),
+        #('tpDeltaPri',         LONG),
+        #('dwFlags',            DWORD),
 
 	def get_exceptions(self, databuffer):
 		pass
 
 	def get_memory(self, buffer):
+		sp = buffer.tell()
 		read_flags = [AllocationProtect.PAGE_EXECUTE_READ,
 				AllocationProtect.PAGE_EXECUTE_READWRITE,
 				AllocationProtect.PAGE_READONLY,
@@ -175,17 +239,33 @@ class LiveSystemReader(MinidumpSystemReader):
 				AllocationProtect.PAGE_WRITECOPY
 		]
 		memlist = MINIDUMP_MEMORY64_LIST()
+		memlist.BaseRva = 0 # TODO: check if this is correct!
 		for section in self.meminfolist.entries:
 			if section.Protect in read_flags:
 				memdesc = MINIDUMP_MEMORY_DESCRIPTOR64()
 				memdesc.StartOfMemoryRange = section.BaseAddress
 				memdesc.DataSize = section.RegionSize
-				print(section.Protect)
-				data = ReadProcessMemory(self.process_handle, section.BaseAddress, section.RegionSize)
-				input(data)
+				#print(section.Protect)
+				#data = ReadProcessMemory(self.process_handle, section.BaseAddress, section.RegionSize)
+				#input(data)
 				memlist.MemoryRanges.append(memdesc)
 
-		return memlist
+		memlist_rva_placeholder_loc = buffer.tell() + 8
+		memlist.to_buffer(buffer)
+		memlist_rva = buffer.tell()
+
+		buffer.seek(memlist_rva_placeholder_loc,0)
+		buffer.write(memlist_rva.to_bytes(8, byteorder = 'little', signed = False))
+		buffer.seek(memlist_rva, 0)
+
+
+		for section in self.meminfolist.entries:
+			if section.Protect in read_flags:
+				data = ReadProcessMemory(self.process_handle, section.BaseAddress, section.RegionSize)
+				if section.RegionSize > len(data):
+					data += b'\x00' * (section.RegionSize + len(data))
+				buffer.write(data)
+		return buffer.tell() - sp #giving back the total size
 #
 #
 #class MinidumpWriter:
@@ -315,10 +395,13 @@ class LiveSystemReader(MinidumpSystemReader):
 #
 #
 if __name__ == '__main__':
+	import sys
 	from minidump.minidumpfile import MinidumpFile
-	pid = 9600
+	pid = int(sys.argv[1])
+	print(pid)
+	enable_debug_privilege()
 	sysreader = LiveSystemReader(pid)
-	with open('test.dmp', 'wb') as f:
+	with open('test_new.dmp', 'wb') as f:
 		mf = MinidumpFile()
 		mf.writer = sysreader
 		mf.to_buffer(f)

--- a/minidump/writer.py
+++ b/minidump/writer.py
@@ -56,18 +56,19 @@ class LiveSystemReader(MinidumpSystemReader):
 		self.process_toolhelp_handle = None
 		self.sysinfo = None
 		self.meminfolist = None
+
+		# TODO: implement more streams. The currently implemented streams are the 'bare minimum' for windbg
 		self.streamtypes = [
 			MINIDUMP_STREAM_TYPE.SystemInfoStream, 
 			MINIDUMP_STREAM_TYPE.ModuleListStream, 
+			MINIDUMP_STREAM_TYPE.ThreadListStream,
+			# MINIDUMP_STREAM_TYPE.ThreadInfoListStream,
+			# MINIDUMP_STREAM_TYPE.UnloadedModuleListStream,
+			# MINIDUMP_STREAM_TYPE.HandleDataStream,
 			MINIDUMP_STREAM_TYPE.MemoryInfoListStream, 
 			MINIDUMP_STREAM_TYPE.Memory64ListStream,
-			MINIDUMP_STREAM_TYPE.UnloadedModuleListStream,
-			MINIDUMP_STREAM_TYPE.HandleDataStream,
-			MINIDUMP_STREAM_TYPE.ThreadInfoListStream,
-			#MINIDUMP_STREAM_TYPE.SystemMemoryInfoStream,
-			MINIDUMP_STREAM_TYPE.ThreadListStream,
-			
 		]
+
 		self.setup()
 
 	def get_available_directories(self):
@@ -216,31 +217,17 @@ class LiveSystemReader(MinidumpSystemReader):
 			mt.SuspendCount = 0
 			mt.PriorityClass = 0
 			mt.Priority = 40
+			# TODO: get thread teb
+			# TODO: get thread context so windbg's stack trace works
 			mt.Teb = 0
-			
 			tl.Threads.append(mt)
 
 		tl.to_buffer(databuffer)
-		
-		#te = Thread32First(self.process_toolhelp_handle)
-		#while te is not None:
-		#	dwThreadId = te.th32ThreadID
-		#	te = Thread32Next(process_toolhelp_handle)
-#
-#
-		#	('dwSize',             DWORD),
-        #('cntUsage',           DWORD),
-        #('th32ThreadID',       DWORD),
-        #('th32OwnerProcessID', DWORD),
-        #('tpBasePri',          LONG),
-        #('tpDeltaPri',         LONG),
-        #('dwFlags',            DWORD),
 
 	def get_exceptions(self, databuffer):
 		pass
 
 	def get_memory(self, buffer):
-		sp = buffer.tell()
 		read_flags = [AllocationProtect.PAGE_EXECUTE_READ,
 				AllocationProtect.PAGE_EXECUTE_READWRITE,
 				AllocationProtect.PAGE_READONLY,
@@ -261,7 +248,7 @@ class LiveSystemReader(MinidumpSystemReader):
 		memlist.to_buffer(buffer)
 		memlist_rva = buffer.tell()
 
-		buffer.seek(memlist_rva_placeholder_loc,0)
+		buffer.seek(memlist_rva_placeholder_loc, 0)
 		buffer.write(memlist_rva.to_bytes(8, byteorder = 'little', signed = False))
 		buffer.seek(memlist_rva, 0)
 

--- a/minidump/writer.py
+++ b/minidump/writer.py
@@ -212,7 +212,7 @@ class LiveSystemReader(MinidumpSystemReader):
 		tl = MINIDUMP_THREAD_LIST()
 		for thread_number in range(2):
 			mt = MINIDUMP_THREAD()
-			mt.ThreadId = 4 * thread_number
+			mt.ThreadId = 4 * (thread_number + 1)
 			mt.SuspendCount = 0
 			mt.PriorityClass = 0
 			mt.Priority = 40


### PR DESCRIPTION
With this pull request, windbg will be able to open the dump and parse it.
Obviously, some windbg features will not work (stack trace wont work because thread context is not retrieved and `!teb` won't work because the teb is not retrieved), but its main functionality will (viewing memory, loaded modules, etc...).

This PR also merges _your_ writer branch into the master.