### PR TITLE
Fix leftover issue with inrange calls

### DIFF
--- a/minidump/__amain__.py
+++ b/minidump/__amain__.py
@@ -28,7 +28,7 @@ async def run():
 	parser.add_argument('--all', action='store_true', help='Show all info')
 	parser.add_argument('-r', '--read-addr', type=lambda x: int(x,0), help='Dump a memory region from the process\'s addres space')
 	parser.add_argument('-s', '--read-size', type=lambda x: int(x,0), default = 0x20, help='Dump a memory region from the process\'s addres space')
-	
+
 	args = parser.parse_args()
 	if args.verbose == 0:
 		logging.basicConfig(level=logging.INFO)
@@ -38,11 +38,11 @@ async def run():
 		logging.basicConfig(level=1)
 
 	print(__banner__)
-	
+
 
 	mf = await AMinidumpFile.parse(args.minidumpfile)
 	reader = mf.get_reader()
-		
+
 	if args.all or args.threads:
 		if mf.threads is not None:
 			print(str(mf.threads))
@@ -81,7 +81,7 @@ async def run():
 			print(str(mf.misc_info))
 	if args.all or args.header:
 		print(str(mf.header))
-			
+
 	if args.read_addr:
 		buff_reader = reader.get_buffered_reader()
 		await buff_reader.move(args.read_addr)

--- a/minidump/__main__.py
+++ b/minidump/__main__.py
@@ -30,7 +30,7 @@ def run():
 	parser.add_argument('--all', action='store_true', help='Show all info')
 	parser.add_argument('-r', '--read-addr', type=lambda x: int(x,0), help='Dump a memory region from the process\'s addres space')
 	parser.add_argument('-s', '--read-size', type=lambda x: int(x,0), default = 0x20, help='Dump a memory region from the process\'s addres space')
-	
+
 	args = parser.parse_args()
 	if args.verbose == 0:
 		logging.basicConfig(level=logging.INFO)
@@ -40,17 +40,17 @@ def run():
 		logging.basicConfig(level=1)
 
 	print(__banner__)
-	
+
 	if args.interactive:
 		shell = MinidumpShell()
 		shell.do_open(args.minidumpfile)
 		shell.cmdloop()
 
 	else:
-		
+
 		mf = MinidumpFile.parse(args.minidumpfile)
 		reader = mf.get_reader()
-		
+
 		if args.all or args.threads:
 			if mf.threads is not None:
 				print(str(mf.threads))
@@ -89,7 +89,7 @@ def run():
 				print(str(mf.misc_info))
 		if args.all or args.header:
 			print(str(mf.header))
-				
+
 		if args.read_addr:
 			buff_reader = reader.get_buffered_reader()
 			buff_reader.move(args.read_addr)

--- a/minidump/_version.py
+++ b/minidump/_version.py
@@ -2,6 +2,6 @@
 __version__ = "0.0.22"
 __banner__ = \
 """
-# minidump %s 
+# minidump %s
 # Author: Tamas Jos @skelsec (skelsecprojects@gmail.com)
 """ % __version__

--- a/minidump/aminidumpreader.py
+++ b/minidump/aminidumpreader.py
@@ -16,7 +16,7 @@ class VirtualSegment:
 		self.start_file_address = start_file_address
 
 		self.data = None
-	
+
 	def inrange(self, start, end):
 		return self.start <= start and end<= self.end
 
@@ -45,11 +45,11 @@ class AMinidumpBufferedMemorySegment:
 		if end is None:
 			await file_handle.seek(self.start_file_address + start)
 			return await file_handle.read(self.end_address - (self.start_file_address + start))
-		
+
 		for chunk in self.chunks:
 			if chunk.inrange(start, end):
 				return chunk.data[start - chunk.start: end - chunk.start]
-		
+
 		if self.total_size <= 2*self.chunksize:
 			chunksize = self.total_size
 			vs = VirtualSegment(0, chunksize, self.start_file_address)
@@ -61,12 +61,12 @@ class AMinidumpBufferedMemorySegment:
 		chunksize = max((end-start), self.chunksize)
 		if start + chunksize > self.end_address:
 			chunksize = self.end_address - start
-		
+
 		vs = VirtualSegment(start, start+chunksize, self.start_file_address + start)
 		await file_handle.seek(vs.start_file_address)
 		vs.data = await file_handle.read(chunksize)
 		self.chunks.append(vs)
-		
+
 		return vs.data[start - vs.start: end - vs.start]
 
 class AMinidumpBufferedReader:

--- a/minidump/aminidumpreader.py
+++ b/minidump/aminidumpreader.py
@@ -157,7 +157,7 @@ class AMinidumpBufferedReader:
 		Returns up to length bytes from the current memory segment
 		"""
 		t = self.current_position + length
-		if not self.current_segment.inrange(t):
+		if not self.current_segment.inrange(t - 1):
 			raise Exception('Would read over segment boundaries!')
 		return await self.current_segment.read(self.reader.file_handle, self.current_position - self.current_segment.start_address , t - self.current_segment.start_address)
 
@@ -177,7 +177,7 @@ class AMinidumpBufferedReader:
 			return await self.current_segment.read(self.reader.file_handle, old_new_pos - self.current_segment.start_address, None)
 
 		t = self.current_position + size
-		if not self.current_segment.inrange(t):
+		if not self.current_segment.inrange(t - 1):
 			raise Exception('Would read over segment boundaries!')
 
 		old_new_pos = self.current_position

--- a/minidump/directory.py
+++ b/minidump/directory.py
@@ -36,7 +36,7 @@ class MINIDUMP_DIRECTORY:
 
 	@staticmethod
 	async def aparse(buff):
-		
+
 		t = await buff.read(4)
 		raw_stream_type_value = int.from_bytes(t, byteorder = 'little', signed = False)
 

--- a/minidump/exceptions.py
+++ b/minidump/exceptions.py
@@ -2,11 +2,11 @@
 class MinidumpException(Exception):
 	"""Generic Exception from minidump module"""
 	pass
-		
+
 class MinidumpHeaderSignatureMismatchException(Exception):
 	"""Header signature was not correct"""
 	pass
-	
+
 class MinidumpHeaderFlagsException(Exception):
 	"""Header flags value was not correct"""
 	pass

--- a/minidump/minidumpfile.py
+++ b/minidump/minidumpfile.py
@@ -84,7 +84,7 @@ class MinidumpFile:
 		for i in range(0, self.header.NumberOfStreams):
 			self.file_handle.seek(self.header.StreamDirectoryRva + i * 12, 0 )
 			minidump_dir = MINIDUMP_DIRECTORY.parse(self.file_handle)
-			
+
 			if minidump_dir:
 				self.directories.append(minidump_dir)
 			else:
@@ -202,7 +202,7 @@ class MinidumpFile:
 			"""
 			elif dir.StreamType == MINIDUMP_STREAM_TYPE.HandleOperationListStream:
 			elif dir.StreamType == MINIDUMP_STREAM_TYPE.LastReservedStream:
-			
+
 			"""
 		try:
 			self.__parse_thread_context()
@@ -219,7 +219,7 @@ class MinidumpFile:
 				thread.ContextObject = CONTEXT.parse(self.file_handle)
 			elif self.sysinfo.ProcessorArchitecture == PROCESSOR_ARCHITECTURE.INTEL:
 				thread.ContextObject = WOW64_CONTEXT.parse(self.file_handle)
-			
+
 
 	def __str__(self):
 		t = '== Minidump File ==\n'

--- a/minidump/minidumpreader.py
+++ b/minidump/minidumpreader.py
@@ -163,7 +163,7 @@ class MinidumpBufferedReader:
 		Returns up to length bytes from the current memory segment
 		"""
 		t = self.current_position + length
-		if not self.current_segment.inrange(t):
+		if not self.current_segment.inrange(t - 1):
 			raise Exception('Would read over segment boundaries!')
 		return self.current_segment.read(self.reader.file_handle, self.current_position - self.current_segment.start_address , t - self.current_segment.start_address)
 

--- a/minidump/minidumpreader.py
+++ b/minidump/minidumpreader.py
@@ -14,10 +14,10 @@ class VirtualSegment:
 		self.end = end
 		self.start_file_address = start_file_address
 
-		
+
 
 		self.data = None
-	
+
 	def inrange(self, start, end):
 		return self.start <= start and end<= self.end
 
@@ -46,11 +46,11 @@ class MinidumpBufferedMemorySegment:
 		if end is None:
 			file_handle.seek(self.start_file_address + start)
 			return file_handle.read(self.end_address - (self.start_file_address + start))
-		
+
 		for chunk in self.chunks:
 			if chunk.inrange(start, end):
 				return chunk.data[start - chunk.start: end - chunk.start]
-		
+
 		if self.total_size <= 2*self.chunksize:
 			chunksize = self.total_size
 			vs = VirtualSegment(0, chunksize, self.start_file_address)
@@ -62,12 +62,12 @@ class MinidumpBufferedMemorySegment:
 		chunksize = max((end-start), self.chunksize)
 		if start + chunksize > self.end_address:
 			chunksize = self.end_address - start
-		
+
 		vs = VirtualSegment(start, start+chunksize, self.start_file_address + start)
 		file_handle.seek(vs.start_file_address)
 		vs.data = file_handle.read(chunksize)
 		self.chunks.append(vs)
-		
+
 		return vs.data[start - vs.start: end - vs.start]
 
 
@@ -335,7 +335,7 @@ class MinidumpFileReader:
 			mod = self.get_unloaded_by_name(module_name)
 			if mod is None:
 				raise Exception('Could not find module! %s' % module_name)
-		
+
 		needles = []
 		for ms in self.memory_segments:
 			if mod.baseaddress <= ms.start_virtual_address < mod.endaddress:

--- a/minidump/minidumpshell.py
+++ b/minidump/minidumpshell.py
@@ -109,7 +109,7 @@ class MinidumpShell(cmd.Cmd):
 		if x is None:
 			print('Reader not yet positioned! Issue a "move" command with the desired memory address!')
 		print(hex(x))
-	
+
 	def do_move(self, position):
 		"""Sets the current position in the process' virtual memory space"""
 		pos = args2int(position)
@@ -145,13 +145,13 @@ class MinidumpShell(cmd.Cmd):
 		data = self.reader.peek(count)
 		print(hexdump( data, length=self.hexdump_size, sep='.', start = pos_before))
 		self.update_prompt(None)
-	
+
 
 def main():
 	import argparse
 
 	parser = argparse.ArgumentParser(description='A parser for minidumnp files')
-	parser.add_argument('-f', '--minidumpfile', help='path to the minidump file of lsass.exe')	
+	parser.add_argument('-f', '--minidumpfile', help='path to the minidump file of lsass.exe')
 	args = parser.parse_args()
 
 	shell = MinidumpShell()

--- a/minidump/streams/CommentStreamA.py
+++ b/minidump/streams/CommentStreamA.py
@@ -9,7 +9,7 @@ class CommentStreamA:
 
 	def to_bytes(self):
 		return self.data.encode('ascii')
-	
+
 	@staticmethod
 	def parse(dir, buff):
 		csa = CommentStreamA()
@@ -24,6 +24,6 @@ class CommentStreamA:
 		csdata = await buff.read(dir.Location.DataSize)
 		csa.data = csdata.decode()
 		return csa
-	
+
 	def __str__(self):
 		return 'CommentA: %s' % self.data

--- a/minidump/streams/CommentStreamW.py
+++ b/minidump/streams/CommentStreamW.py
@@ -9,14 +9,14 @@ class CommentStreamW:
 
 	def to_bytes(self):
 		return self.data.encode('utf-16-le')
-	
+
 	@staticmethod
 	def parse(dir, buff):
 		csa = CommentStreamW()
 		buff.seek(dir.Location.Rva)
 		csa.data = buff.read(dir.Location.DataSize).decode('utf-16-le')
 		return csa
-	
+
 	@staticmethod
 	async def aparse(dir, buff):
 		csa = CommentStreamW()
@@ -24,6 +24,6 @@ class CommentStreamW:
 		csdata = await buff.read(dir.Location.DataSize)
 		csa.data = csdata.decode('utf-16-le')
 		return csa
-		
+
 	def __str__(self):
 		return 'CommentW: %s' % self.data

--- a/minidump/streams/ContextStream.py
+++ b/minidump/streams/ContextStream.py
@@ -38,17 +38,17 @@ class NEON128(M128A):
 # https://www.vergiliusproject.com/kernels/x64/Windows%20Vista%20%7C%202008/SP2/_XMM_SAVE_AREA32
 class XMM_SAVE_AREA32:
     def __init__(self):
-        self.ControlWord = 0                               # 0x0 USHORT 
-        self.StatusWord = 0                                # 0x2 USHORT 
-        self.TagWord = 0                                   # 0x4 UCHAR 
-        self.Reserved1 = 0                                 # 0x5 UCHAR 
+        self.ControlWord = 0                               # 0x0 USHORT
+        self.StatusWord = 0                                # 0x2 USHORT
+        self.TagWord = 0                                   # 0x4 UCHAR
+        self.Reserved1 = 0                                 # 0x5 UCHAR
         self.ErrorOpcode = 0                               # 0x6 USHORT
         self.ErrorOffset = 0                               # 0x8 ULONG
-        self.ErrorSelector = 0                             # 0xc USHORT 
-        self.Reserved2 = 0                                 # 0xe USHORT 
+        self.ErrorSelector = 0                             # 0xc USHORT
+        self.Reserved2 = 0                                 # 0xe USHORT
         self.DataOffset = 0                                # 0x10 ULONG
-        self.DataSelector = 0                              # 0x14 USHORT 
-        self.Reserved3 = 0                                 # 0x16 USHORT 
+        self.DataSelector = 0                              # 0x14 USHORT
+        self.Reserved3 = 0                                 # 0x16 USHORT
         self.MxCsr = 0                                     # 0x18 ULONG
         self.MxCsr_Mask = 0                                # 0x1c ULONG
         self.FloatRegisters = []                           # 0x20 struct M128A[8]
@@ -128,7 +128,7 @@ class CTX_DUMMYSTRUCTNAME:
         self.Xmm13 = 0
         self.Xmm14 = 0
         self.Xmm15 = 0
-    
+
     @classmethod
     def parse(cls, buff):
         dsn = cls()
@@ -189,7 +189,7 @@ class CTX_DUMMYUNIONNAME:
         self.D = []                        # ULONGLONG [32]
         self.DUMMYSTRUCTNAME = []
         self.S = []                        # DWORD [32]
-    
+
     @classmethod
     def parse(cls, buff):
         dun = cls()
@@ -221,7 +221,7 @@ class CTX_DUMMYUNIONNAME:
             s += "\t%d" % (e)
 
         return s
-        
+
 
 # https:# docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-context
 class CONTEXT:
@@ -265,7 +265,7 @@ class CONTEXT:
         self.R15 = 0   # DWORD64
         self.Rip = 0   # DWORD64
         self.DUMMYUNIONNAME = None
-        
+
         self.VectorRegister = []         # M128A   [26]
         self.VectorControl = 0           # DWORD64
         self.DebugControl = 0            # DWORD64
@@ -277,7 +277,7 @@ class CONTEXT:
     @classmethod
     def parse(cls, buff):
         ctx = cls()
-        
+
         ctx.P1Home = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)   # DWORD64
         ctx.P2Home = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)   # DWORD64
         ctx.P3Home = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)   # DWORD64
@@ -317,7 +317,7 @@ class CONTEXT:
         ctx.R15 = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)   # DWORD64
         ctx.Rip = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)   # DWORD64
         ctx.DUMMYUNIONNAME = CTX_DUMMYUNIONNAME.parse(buff)
-        
+
         ctx.VectorRegister = M128A.parse_array(buff, 26)         # M128A   [26]
         ctx.VectorControl =  int.from_bytes(buff.read(8), byteorder = 'little', signed = False)       # DWORD64
         ctx.DebugControl = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)         # DWORD64
@@ -329,7 +329,7 @@ class CONTEXT:
         return ctx
 
     def __str__(self):
-        s = "" 
+        s = ""
         s += "%s: 0x%x (%d)\n" % ("P1Home",self.P1Home,self.P1Home)
         s += "%s: 0x%x (%d)\n" % ("P2Home",self.P2Home,self.P2Home)
         s += "%s: 0x%x (%d)\n" % ("P3Home",self.P3Home,self.P3Home)
@@ -386,7 +386,7 @@ class WOW64_FLOATING_SAVE_AREA:
         self.DataSelector = 0 # DWORD
         self.RegisterArea = []  # BYTE
         self.Cr0NpxState = 0  # DWORD
-    
+
     @classmethod
     def parse(cls, buff):
         ctx = cls()
@@ -400,7 +400,7 @@ class WOW64_FLOATING_SAVE_AREA:
         ctx.RegisterArea = int.from_bytes(buff.read(80), byteorder = 'little', signed = False)
         ctx.Cr0NpxState = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
         return ctx
-        
+
     def __str__(self):
         s = ''
         s += "ControlWord: %x (%d)\n" % (self.ControlWord, self.ControlWord)

--- a/minidump/streams/FunctionTableStream.py
+++ b/minidump/streams/FunctionTableStream.py
@@ -11,7 +11,7 @@ class MINIDUMP_FUNCTION_TABLE_STREAM:
 		self.SizeOfFunctionEntry = None
 		self.NumberOfDescriptors = None
 		self.SizeOfAlignPad = None
-	
+
 	@staticmethod
 	def parse(dir, buff):
 		mfts = MINIDUMP_FUNCTION_TABLE_STREAM()
@@ -21,5 +21,5 @@ class MINIDUMP_FUNCTION_TABLE_STREAM:
 		mfts.SizeOfFunctionEntry = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mfts.NumberOfDescriptors = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mfts.SizeOfAlignPad = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
-			
+
 		return mfts

--- a/minidump/streams/HandleOperationListStream.py
+++ b/minidump/streams/HandleOperationListStream.py
@@ -9,7 +9,7 @@ class MINIDUMP_HANDLE_OPERATION_LIST:
 		self.SizeOfEntry = None
 		self.NumberOfEntries = None
 		self.Reserved = None
-	
+
 	@staticmethod
 	def parse(dir, buff):
 		mhds = MINIDUMP_HANDLE_OPERATION_LIST()
@@ -17,6 +17,5 @@ class MINIDUMP_HANDLE_OPERATION_LIST:
 		mhds.SizeOfEntry = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mhds.NumberOfEntries = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mhds.Reserved = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
-			
+
 		return mhds
-		

--- a/minidump/streams/LastReservedStream.py
+++ b/minidump/streams/LastReservedStream.py
@@ -8,7 +8,7 @@ class MINIDUMP_USER_STREAM:
 		self.Type = None
 		self.BufferSize = None
 		self.Buffer = None
-	
+
 	@staticmethod
 	def parse(buff):
 		mus = MINIDUMP_USER_STREAM()
@@ -16,5 +16,5 @@ class MINIDUMP_USER_STREAM:
 		mus.BufferSize = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)
 		#this type is PVOID, not sure on the size
 		mus.Buffer = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
-			
+
 		return mus

--- a/minidump/streams/Memory64ListStream.py
+++ b/minidump/streams/Memory64ListStream.py
@@ -4,7 +4,7 @@
 #  Tamas Jos (@skelsec)
 #
 import io
-from minidump.common_structs import * 
+from minidump.common_structs import *
 
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms680387(v=vs.85).aspx
 class MINIDUMP_MEMORY64_LIST:
@@ -22,7 +22,7 @@ class MINIDUMP_MEMORY64_LIST:
 		for memrange in self.MemoryRanges:
 			t += memrange.to_bytes()
 		return t
-	
+
 	@staticmethod
 	def parse(buff):
 		mml = MINIDUMP_MEMORY64_LIST()
@@ -32,14 +32,14 @@ class MINIDUMP_MEMORY64_LIST:
 		mml.BaseRva = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)
 		for _ in range(mml.NumberOfMemoryRanges):
 			mml.MemoryRanges.append(MINIDUMP_MEMORY_DESCRIPTOR64.parse(buff))
-			
+
 			#sometimes buggy minidumps have a wrong number of memory ranges, so we need to check if we reached the end of the buffer
 			curpos = buff.tell()
 			if curpos == buffsize:
 				break
-		
+
 		return mml
-		
+
 	def __str__(self):
 		t  = '== MINIDUMP_MEMORY64_LIST ==\n'
 		t += 'NumberOfMemoryRanges: %s\n' % self.NumberOfMemoryRanges
@@ -62,14 +62,14 @@ class MINIDUMP_MEMORY_DESCRIPTOR64:
 		t = self.StartOfMemoryRange.to_bytes(8, byteorder = 'little', signed = False)
 		t += self.DataSize.to_bytes(8, byteorder = 'little', signed = False)
 		return t
-		
+
 	@staticmethod
 	def parse(buff):
 		md = MINIDUMP_MEMORY_DESCRIPTOR64()
 		md.StartOfMemoryRange = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)
 		md.DataSize = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)
 		return md
-		
+
 	def __str__(self):
 		t = 'Start: %s' % hex(self.StartOfMemoryRange)
 		t += 'Size: %s' % self.DataSize
@@ -78,7 +78,7 @@ class MINIDUMP_MEMORY_DESCRIPTOR64:
 class MinidumpMemory64List:
 	def __init__(self):
 		self.memory_segments = []
-	
+
 	@staticmethod
 	def parse(dir, buff):
 		t = MinidumpMemory64List()
@@ -104,14 +104,13 @@ class MinidumpMemory64List:
 			mml.memory_segments.append(ms)
 			rva += mod.DataSize
 		return mml
-		
+
 	def to_table(self):
 		t = []
 		t.append(MinidumpMemorySegment.get_header())
 		for mod in self.memory_segments:
 			t.append(mod.to_row())
 		return t
-		
+
 	def __str__(self):
 		return '== MinidumpMemory64List ==\n' + construct_table(self.to_table())
-	

--- a/minidump/streams/MemoryInfoListStream.py
+++ b/minidump/streams/MemoryInfoListStream.py
@@ -5,7 +5,7 @@
 #
 import io
 import enum
-from minidump.common_structs import * 
+from minidump.common_structs import *
 
 class AllocationProtect(enum.Enum):
 	NONE = 0
@@ -51,7 +51,7 @@ class AllocationProtect(enum.Enum):
 	#The PAGE_WRITECOMBINE flag cannot be specified with the PAGE_NOACCESS, PAGE_GUARD, and PAGE_NOCACHE flags.
 	#The PAGE_WRITECOMBINE flag can be used only when allocating private memory with the VirtualAlloc, VirtualAllocEx, or VirtualAllocExNuma functions. To enable write-combined memory access for shared memory, specify the SEC_WRITECOMBINE flag when calling the CreateFileMapping function.
 	#Windows Server 2003 and Windows XP:  This flag is not supported until Windows Server 2003 with SP1.
-	
+
 class MemoryType(enum.Enum):
 	MEM_IMAGE = 0x1000000 #Indicates that the memory pages within the region are mapped into the view of an image section.
 	MEM_MAPPED = 0x40000 #Indicates that the memory pages within the region are mapped into the view of a section.
@@ -78,17 +78,17 @@ class MINIDUMP_MEMORY_INFO_LIST:
 		t += self.SizeOfEntry.to_bytes(4, byteorder = 'little', signed = False)
 		t += len(self.entries).to_bytes(8, byteorder = 'little', signed = False)
 		return t
-	
+
 	@staticmethod
 	def parse(buff):
 		mhds = MINIDUMP_MEMORY_INFO_LIST()
 		mhds.SizeOfHeader = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mhds.SizeOfEntry = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mhds.NumberOfEntries = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)
-			
+
 		return mhds
-		
-# https://msdn.microsoft.com/en-us/library/windows/desktop/ms680386(v=vs.85).aspx	
+
+# https://msdn.microsoft.com/en-us/library/windows/desktop/ms680386(v=vs.85).aspx
 class MINIDUMP_MEMORY_INFO:
 	def __init__(self):
 		self.BaseAddress = None
@@ -121,7 +121,7 @@ class MINIDUMP_MEMORY_INFO:
 		t += self.Type.value.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.__alignment2.to_bytes(4, byteorder = 'little', signed = False)
 		return t
-	
+
 	@staticmethod
 	def parse(buff):
 		mmi = MINIDUMP_MEMORY_INFO()
@@ -143,9 +143,9 @@ class MINIDUMP_MEMORY_INFO:
 		except:
 			pass
 		mmi.__alignment2 = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
-			
+
 		return mmi
-		
+
 class MinidumpMemoryInfo:
 	def __init__(self):
 		self.BaseAddress = None
@@ -155,7 +155,7 @@ class MinidumpMemoryInfo:
 		self.State = None
 		self.Protect = None
 		self.Type = None
-	
+
 	@staticmethod
 	def parse(t, buff):
 		mmi = MinidumpMemoryInfo()
@@ -167,7 +167,7 @@ class MinidumpMemoryInfo:
 		mmi.Protect = t.Protect
 		mmi.Type = t.Type
 		return mmi
-	
+
 	@staticmethod
 	def get_header():
 		t = [
@@ -192,13 +192,13 @@ class MinidumpMemoryInfo:
 			self.Type.name if self.Type else 'N/A',
 		]
 		return t
-		
-		
+
+
 class MinidumpMemoryInfoList:
 	def __init__(self):
 		self.header = None
 		self.infos = []
-	
+
 	@staticmethod
 	def parse(dir, buff):
 		t = MinidumpMemoryInfoList()
@@ -209,7 +209,7 @@ class MinidumpMemoryInfoList:
 		for _ in range(t.header.NumberOfEntries):
 			mi = MINIDUMP_MEMORY_INFO.parse(chunk)
 			t.infos.append(MinidumpMemoryInfo.parse(mi, buff))
-		
+
 		return t
 
 	@staticmethod
@@ -222,15 +222,15 @@ class MinidumpMemoryInfoList:
 		for _ in range(t.header.NumberOfEntries):
 			mi = MINIDUMP_MEMORY_INFO.parse(chunk)
 			t.infos.append(MinidumpMemoryInfo.parse(mi, None))
-		
+
 		return t
-		
+
 	def to_table(self):
 		t = []
 		t.append(MinidumpMemoryInfo.get_header())
 		for info in self.infos:
 			t.append(info.to_row())
 		return t
-	
+
 	def __str__(self):
 		return '== MinidumpMemoryInfoList ==\n' + construct_table(self.to_table())

--- a/minidump/streams/MemoryListStream.py
+++ b/minidump/streams/MemoryListStream.py
@@ -4,7 +4,7 @@
 #  Tamas Jos (@skelsec)
 #
 import io
-from minidump.common_structs import * 
+from minidump.common_structs import *
 
 # https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_memory_list
 class MINIDUMP_MEMORY_LIST:
@@ -17,16 +17,16 @@ class MINIDUMP_MEMORY_LIST:
 		for memrange in self.MemoryRanges:
 			t += memrange.to_bytes()
 		return t
-		
+
 	@staticmethod
 	def parse(buff):
 		mml = MINIDUMP_MEMORY_LIST()
 		mml.NumberOfMemoryRanges = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		for _ in range(mml.NumberOfMemoryRanges):
 			mml.MemoryRanges.append(MINIDUMP_MEMORY_DESCRIPTOR.parse(buff))
-		
+
 		return mml
-		
+
 	def __str__(self):
 		t  = '== MINIDUMP_MEMORY_LIST ==\n'
 		t += 'NumberOfMemoryRanges: %s\n' % self.NumberOfMemoryRanges
@@ -34,12 +34,12 @@ class MINIDUMP_MEMORY_LIST:
 			t+= str(range)
 		return t
 
-# https://msdn.microsoft.com/en-us/library/windows/desktop/ms680384(v=vs.85).aspx		
+# https://msdn.microsoft.com/en-us/library/windows/desktop/ms680384(v=vs.85).aspx
 class MINIDUMP_MEMORY_DESCRIPTOR:
 	def __init__(self):
 		self.StartOfMemoryRange = None
 		self.MemoryLocation = None
-		
+
 		#we do not use MemoryLocation but immediately store its fields in this object for easy access
 		self.DataSize = None
 		self.Rva = None
@@ -48,12 +48,12 @@ class MINIDUMP_MEMORY_DESCRIPTOR:
 		t = self.StartOfMemoryRange.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.MemoryLocation.to_bytes()
 		return t
-		
+
 	@staticmethod
 	def parse(buff):
 		md = MINIDUMP_MEMORY_DESCRIPTOR()
 		md.StartOfMemoryRange = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)
-		
+
 		#TODO: figure out what the documentation says, the person writign it was probably high...
 		# The deal is: RVA sizes differ on where in the file the memory data is stored. but it's not possible to know it up front if we need to read 32 or 64 bytes...
 		#
@@ -61,22 +61,22 @@ class MINIDUMP_MEMORY_DESCRIPTOR:
 		#	md.MemoryLocation = MINIDUMP_LOCATION_DESCRIPTOR.parse(buff)
 		#else:
 		#	md.MemoryLocation = MINIDUMP_LOCATION_DESCRIPTOR64.parse(buff)
-		
+
 		md.MemoryLocation = MINIDUMP_LOCATION_DESCRIPTOR.parse(buff)
 		md.DataSize = md.MemoryLocation.DataSize
 		md.Rva = md.MemoryLocation.Rva
 		return md
-		
+
 	def __str__(self):
 		t =  'Start: %s' % hex(self.StartOfMemoryRange)
 		t += 'Size: %s' % self.DataSize
 		t += 'Rva: %s' % self.Rva
 		return t
-		
+
 class MinidumpMemoryList:
 	def __init__(self):
 		self.memory_segments = []
-	
+
 	@staticmethod
 	def parse(dir, buff):
 		t = MinidumpMemoryList()
@@ -86,7 +86,7 @@ class MinidumpMemoryList:
 		for mod in mtl.MemoryRanges:
 			t.memory_segments.append(MinidumpMemorySegment.parse_mini(mod, buff))
 		return t
-	
+
 	@staticmethod
 	async def aparse(dir, buff):
 		t = MinidumpMemoryList()
@@ -97,7 +97,7 @@ class MinidumpMemoryList:
 		for mod in mtl.MemoryRanges:
 			t.memory_segments.append(MinidumpMemorySegment.parse_mini(mod, buff))
 		return t
-		
+
 	def __str__(self):
 		t  = '== MinidumpMemoryList ==\n'
 		for mod in self.memory_segments:

--- a/minidump/streams/MiscInfoStream.py
+++ b/minidump/streams/MiscInfoStream.py
@@ -6,7 +6,7 @@
 import io
 import enum
 
-#https://msdn.microsoft.com/en-us/library/windows/desktop/ms680388(v=vs.85).aspx	
+#https://msdn.microsoft.com/en-us/library/windows/desktop/ms680388(v=vs.85).aspx
 class MinidumpMiscInfo2Flags1(enum.IntFlag):
 	MINIDUMP_MISC1_PROCESS_ID = 0x00000001 #ProcessId is used.
 	MINIDUMP_MISC1_PROCESS_TIMES = 0x00000002 #ProcessCreateTime, ProcessKernelTime, and ProcessUserTime are used.
@@ -27,7 +27,7 @@ class MINIDUMP_MISC_INFO:
 		self.ProcessCreateTime = None
 		self.ProcessUserTime = None
 		self.ProcessKernelTime = None
-	
+
 	@staticmethod
 	def parse(buff):
 		mmi = MINIDUMP_MISC_INFO()
@@ -43,10 +43,10 @@ class MINIDUMP_MISC_INFO:
 			mmi.ProcessKernelTime = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		else:
 			buff.read(12)
-			
+
 		return mmi
 
-#https://msdn.microsoft.com/en-us/library/windows/desktop/ms680388(v=vs.85).aspx		
+#https://msdn.microsoft.com/en-us/library/windows/desktop/ms680388(v=vs.85).aspx
 class MINIDUMP_MISC_INFO_2:
 	size = 44
 	def __init__(self):
@@ -61,7 +61,7 @@ class MINIDUMP_MISC_INFO_2:
 		self.ProcessorMhzLimit = None
 		self.ProcessorMaxIdleState = None
 		self.ProcessorCurrentIdleState = None
-	
+
 	@staticmethod
 	def parse(buff):
 		mmi = MINIDUMP_MISC_INFO_2()
@@ -85,9 +85,9 @@ class MINIDUMP_MISC_INFO_2:
 			mmi.ProcessorCurrentIdleState = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		else:
 			buff.read(20)
-		
+
 		return mmi
-		
+
 class MinidumpMiscInfo:
 	def __init__(self):
 		self.ProcessId = None
@@ -99,7 +99,7 @@ class MinidumpMiscInfo:
 		self.ProcessorMhzLimit = None
 		self.ProcessorMaxIdleState = None
 		self.ProcessorCurrentIdleState = None
-	
+
 	@staticmethod
 	def parse(dir, buff):
 		t = MinidumpMiscInfo()
@@ -148,7 +148,7 @@ class MinidumpMiscInfo:
 			t.ProcessorMaxIdleState = misc.ProcessorMaxIdleState
 			t.ProcessorCurrentIdleState = misc.ProcessorCurrentIdleState
 		return t
-		
+
 	def __str__(self):
 		t  = '== MinidumpMiscInfo ==\n'
 		t += 'ProcessId %s\n' % self.ProcessId

--- a/minidump/streams/ThreadExListStream.py
+++ b/minidump/streams/ThreadExListStream.py
@@ -5,7 +5,7 @@
 #
 
 import io
-from minidump.common_structs import * 
+from minidump.common_structs import *
 from minidump.streams.MemoryListStream import MINIDUMP_MEMORY_DESCRIPTOR
 
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms680399(v=vs.85).aspx
@@ -13,16 +13,16 @@ class MINIDUMP_THREAD_EX_LIST:
 	def __init__(self):
 		self.NumberOfThreads = None
 		self.Threads = []
-	
+
 	@staticmethod
 	def parse(buff):
 		mtel = MINIDUMP_THREAD_EX_LIST()
 		mtel.NumberOfThreads = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		for _ in range(mtel.NumberOfThreads):
 			mtel.Threads.append(MINIDUMP_THREAD_EX.parse(buff))
-		
+
 		return mtel
-		
+
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms680400(v=vs.85).aspx
 class MINIDUMP_THREAD_EX:
 	def __init__(self):
@@ -34,7 +34,7 @@ class MINIDUMP_THREAD_EX:
 		self.Stack = None
 		self.ThreadContext = None
 		self.BackingStore = None
-	
+
 	@staticmethod
 	def parse(buff):
 		mte = MINIDUMP_THREAD_EX()
@@ -47,7 +47,7 @@ class MINIDUMP_THREAD_EX:
 		mte.ThreadContext = MINIDUMP_LOCATION_DESCRIPTOR.parse(buff)
 		mte.BackingStore = MINIDUMP_MEMORY_DESCRIPTOR.parse(buff)
 		return mte
-	
+
 	@staticmethod
 	def get_header():
 		return [
@@ -59,7 +59,7 @@ class MINIDUMP_THREAD_EX:
 			#'Stack',
 			#'ThreadContext',
 		]
-	
+
 	def to_row(self):
 		return [
 			hex(self.ThreadId),
@@ -70,12 +70,12 @@ class MINIDUMP_THREAD_EX:
 			#self.Stack,
 			#self.ThreadContext,
 		]
-		
-		
+
+
 class MinidumpThreadExList:
 	def __init__(self):
 		self.threads = []
-	
+
 	@staticmethod
 	def parse(dir, buff):
 		t = MinidumpThreadExList()
@@ -94,14 +94,13 @@ class MinidumpThreadExList:
 		mtl = MINIDUMP_THREAD_EX_LIST.parse(chunk)
 		t.threads = mtl.Threads
 		return t
-	
+
 	def to_table(self):
 		t = []
 		t.append(MINIDUMP_THREAD_EX.get_header())
 		for thread in self.threads:
 			t.append(thread.to_row())
 		return t
-		
+
 	def __str__(self):
-		return '== ThreadExList ==\n' + construct_table(self.to_table())	
-	
+		return '== ThreadExList ==\n' + construct_table(self.to_table())

--- a/minidump/streams/ThreadInfoListStream.py
+++ b/minidump/streams/ThreadInfoListStream.py
@@ -5,7 +5,7 @@
 #
 import io
 import enum
-from minidump.common_structs import * 
+from minidump.common_structs import *
 
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms680510(v=vs.85).aspx
 class DumpFlags(enum.Enum):
@@ -22,7 +22,7 @@ class MINIDUMP_THREAD_INFO_LIST:
 		self.SizeOfHeader = None
 		self.SizeOfEntry = None
 		self.NumberOfEntries = None
-	
+
 	def to_bytes(self):
 		t = self.SizeOfHeader.value.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.SizeOfEntry.to_bytes(4, byteorder = 'little', signed = False)
@@ -35,10 +35,10 @@ class MINIDUMP_THREAD_INFO_LIST:
 		mtil.SizeOfHeader = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mtil.SizeOfEntry = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mtil.NumberOfEntries = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
-		
+
 		return mtil
-		
-	
+
+
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms680510(v=vs.85).aspx
 class MINIDUMP_THREAD_INFO:
 	def __init__(self):
@@ -68,7 +68,7 @@ class MINIDUMP_THREAD_INFO:
 		t += self.StartAddress.to_bytes(8, byteorder = 'little', signed = False)
 		t += self.Affinity.to_bytes(8, byteorder = 'little', signed = False)
 		return t
-	
+
 	@staticmethod
 	def parse(buff):
 		mti = MINIDUMP_THREAD_INFO()
@@ -86,7 +86,7 @@ class MINIDUMP_THREAD_INFO:
 		mti.StartAddress = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)
 		mti.Affinity = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)
 		return mti
-		
+
 class MinidumpThreadInfo:
 	def __init__(self):
 		self.ThreadId = None
@@ -99,7 +99,7 @@ class MinidumpThreadInfo:
 		self.UserTime = None
 		self.StartAddress = None
 		self.Affinity = None
-	
+
 	@staticmethod
 	def parse(t, buff):
 		mti = MinidumpThreadInfo()
@@ -114,7 +114,7 @@ class MinidumpThreadInfo:
 		mti.StartAddress = t.StartAddress
 		mti.Affinity = t.Affinity
 		return mti
-	
+
 	@staticmethod
 	def get_header():
 		return [
@@ -129,7 +129,7 @@ class MinidumpThreadInfo:
 			'StartAddress',
 			'Affinity',
 		]
-	
+
 	def to_row(self):
 		return [
 			hex(self.ThreadId),
@@ -143,16 +143,16 @@ class MinidumpThreadInfo:
 			hex(self.StartAddress),
 			str(self.Affinity),
 		]
-		
+
 	def __str__(self):
 		return 'ThreadId: %x DumpFlags: %s DumpError: %s ExitStatus: %x CreateTime: %s ExitTime: %s KernelTime: %s UserTime: %s StartAddress: %x Affinity: %d' % \
 			(self.ThreadId, self.DumpFlags, self.DumpError, self.ExitStatus, self.CreateTime, self.ExitTime, self.KernelTime, self.UserTime, self.StartAddress, self.Affinity)
-		
+
 class MinidumpThreadInfoList:
 	def __init__(self):
 		self.header = None
 		self.infos = []
-	
+
 	@staticmethod
 	def parse(dir, buff):
 		t = MinidumpThreadInfoList()
@@ -163,7 +163,7 @@ class MinidumpThreadInfoList:
 		for _ in range(t.header.NumberOfEntries):
 			mi = MINIDUMP_THREAD_INFO.parse(chunk)
 			t.infos.append(MinidumpThreadInfo.parse(mi, buff))
-		
+
 		return t
 
 	@staticmethod
@@ -176,16 +176,15 @@ class MinidumpThreadInfoList:
 		for _ in range(t.header.NumberOfEntries):
 			mi = MINIDUMP_THREAD_INFO.parse(chunk)
 			t.infos.append(MinidumpThreadInfo.parse(mi, None))
-		
+
 		return t
-		
+
 	def to_table(self):
 		t = []
 		t.append(MinidumpThreadInfo.get_header())
 		for info in self.infos:
 			t.append(info.to_row())
 		return t
-		
+
 	def __str__(self):
-		return '== ThreadInfoList ==\n' + construct_table(self.to_table())	
-	
+		return '== ThreadInfoList ==\n' + construct_table(self.to_table())

--- a/minidump/streams/ThreadListStream.py
+++ b/minidump/streams/ThreadListStream.py
@@ -4,7 +4,7 @@
 #  Tamas Jos (@skelsec)
 #
 import io
-from minidump.common_structs import * 
+from minidump.common_structs import *
 from minidump.streams.MemoryListStream import MINIDUMP_MEMORY_DESCRIPTOR
 
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms680515(v=vs.85).aspx
@@ -18,7 +18,7 @@ class MINIDUMP_THREAD_LIST:
 		for th in self.Threads:
 			t += th.to_bytes()
 		return t
-	
+
 	@staticmethod
 	def parse(buff):
 		mtl = MINIDUMP_THREAD_LIST()
@@ -26,8 +26,8 @@ class MINIDUMP_THREAD_LIST:
 		for _ in range(mtl.NumberOfThreads):
 			mtl.Threads.append(MINIDUMP_THREAD.parse(buff))
 		return mtl
-	
-# https://msdn.microsoft.com/en-us/library/windows/desktop/ms680517(v=vs.85).aspx	
+
+# https://msdn.microsoft.com/en-us/library/windows/desktop/ms680517(v=vs.85).aspx
 class MINIDUMP_THREAD:
 	def __init__(self):
 		self.ThreadId = None
@@ -47,7 +47,7 @@ class MINIDUMP_THREAD:
 		t += self.Stack.to_bytes()
 		t += self.ThreadContext.to_bytes()
 		return t
-	
+
 	@staticmethod
 	def parse(buff):
 		mt = MINIDUMP_THREAD()
@@ -58,9 +58,9 @@ class MINIDUMP_THREAD:
 		mt.Teb = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)
 		mt.Stack = MINIDUMP_MEMORY_DESCRIPTOR.parse(buff)
 		mt.ThreadContext = MINIDUMP_LOCATION_DESCRIPTOR.parse(buff)
-		
+
 		return mt
-	
+
 	@staticmethod
 	def get_header():
 		return [
@@ -72,7 +72,7 @@ class MINIDUMP_THREAD:
 			#'Stack',
 			#'ThreadContext',
 		]
-	
+
 	def to_row(self):
 		return [
 			hex(self.ThreadId),
@@ -83,11 +83,11 @@ class MINIDUMP_THREAD:
 			#self.Stack,
 			#self.ThreadContext,
 		]
-		
+
 class MinidumpThreadList:
 	def __init__(self):
 		self.threads = []
-	
+
 	@staticmethod
 	def parse(dir, buff):
 		t = MinidumpThreadList()
@@ -106,13 +106,13 @@ class MinidumpThreadList:
 		mtl = MINIDUMP_THREAD_LIST.parse(chunk)
 		t.threads = mtl.Threads
 		return t
-		
+
 	def to_table(self):
 		t = []
 		t.append(MINIDUMP_THREAD.get_header())
 		for thread in self.threads:
 			t.append(thread.to_row())
 		return t
-		
+
 	def __str__(self):
 		return 'ThreadList\n' + construct_table(self.to_table())

--- a/minidump/utils/winapi/kernel32.py
+++ b/minidump/utils/winapi/kernel32.py
@@ -19,7 +19,7 @@ class WindowsMinBuild(enum.Enum):
 	WIN_10 = 9800
 
 #utter microsoft bullshit commencing..
-def getWindowsBuild():   
+def getWindowsBuild():
     class OSVersionInfo(ctypes.Structure):
         _fields_ = [
             ("dwOSVersionInfoSize" , ctypes.c_int),
@@ -31,7 +31,7 @@ def getWindowsBuild():
     GetVersionEx = getattr( ctypes.windll.kernel32 , "GetVersionExA")
     version  = OSVersionInfo()
     version.dwOSVersionInfoSize = ctypes.sizeof(OSVersionInfo)
-    GetVersionEx( ctypes.byref(version) )    
+    GetVersionEx( ctypes.byref(version) )
     return version.dwBuildNumber
 
 def get_all_access_flags():

--- a/minidump/win_datatypes.py
+++ b/minidump/win_datatypes.py
@@ -11,7 +11,7 @@ class POINTER:
 		self.location = reader.tell()
 		self.value = reader.read_uint()
 		self.finaltype = finaltype
-		
+
 	def read(self, reader, override_finaltype = None):
 		if self.value == 0:
 			return None
@@ -23,7 +23,7 @@ class POINTER:
 			data = self.finaltype(reader)
 		reader.move(pos)
 		return data
-	
+
 	def read_raw(self, reader, size ):
 		#we do not know the finaltype, just want the data
 		if self.value == 0:
@@ -33,23 +33,23 @@ class POINTER:
 		data = reader.read(size)
 		reader.move(pos)
 		return data
-		
+
 class PVOID(POINTER):
 	def __init__(self, reader):
 		super().__init__(reader, None) #with void we cannot determine the final type
-		
+
 class BOOL:
 	def __init__(self, reader):
 		self.value = bool(reader.read_uint())
-		
+
 class BOOLEAN:
 	def __init__(self, reader):
 		self.value = reader.read(1)
-		
+
 class BYTE:
 	def __init__(self, reader):
 		self.value = reader.read(1)
-		
+
 class PBYTE(POINTER):
 	def __init__(self, reader):
 		super().__init__(reader, BYTE)
@@ -57,52 +57,52 @@ class PBYTE(POINTER):
 class CCHAR:
 	def __init__(self, reader):
 		self.value = reader.read(1).decode('ascii')
-		
+
 class CHAR:
 	def __init__(self, reader):
 		self.value = reader.read(1).decode('ascii')
-		
+
 class UCHAR:
 	def __init__(self, reader):
 		self.value = int.from_bytes(reader.read(1), byteorder = 'little', signed = False)
 
 class WORD:
 	def __init__(self, reader):
-		self.value = int.from_bytes(reader.read(2), byteorder = 'little', signed = False)		
+		self.value = int.from_bytes(reader.read(2), byteorder = 'little', signed = False)
 
 class DWORD:
 	def __init__(self, reader):
 		self.value = int.from_bytes(reader.read(4), byteorder = 'little', signed = False)
-		
+
 class DWORDLONG:
 	def __init__(self, reader):
 		self.value = int.from_bytes(reader.read(8), byteorder = 'little', signed = False)
-		
+
 class DWORD_PTR(POINTER):
 	def __init__(self, reader):
 		super().__init__(reader, DWORD)
-		
+
 class DWORD32:
 	def __init__(self, reader):
 		self.value = int.from_bytes(reader.read(4), byteorder = 'little', signed = False)
 
 class DWORD64:
 	def __init__(self, reader):
-		self.value = int.from_bytes(reader.read(8), byteorder = 'little', signed = False)		
+		self.value = int.from_bytes(reader.read(8), byteorder = 'little', signed = False)
 
-	
+
 class HANDLE:
 	def __init__(self, reader):
 		self.value = reader.read_uint()
-		
+
 class HFILE:
 	def __init__(self, reader):
 		self.value = int.from_bytes(reader.read(4), byteorder = 'little', signed = False)
-		
+
 class HINSTANCE:
 	def __init__(self, reader):
-		self.value = reader.read_uint()		
-		
+		self.value = reader.read_uint()
+
 
 class HKEY:
 	def __init__(self, reader):
@@ -112,7 +112,7 @@ class HKEY:
 class HKL:
 	def __init__(self, reader):
 		self.value = reader.read_uint()
-		
+
 class HLOCAL:
 	def __init__(self, reader):
 		self.value = reader.read_uint()
@@ -180,7 +180,7 @@ class LPBYTE(POINTER):
 class ULONG:
 	def __init__(self, reader):
 		self.value = int.from_bytes(reader.read(4), byteorder = 'little', signed = False)
-		
+
 class ULONGLONG:
 	def __init__(self, reader):
 		self.value = int.from_bytes(reader.read(8), byteorder = 'little', signed = False)
@@ -188,51 +188,50 @@ class ULONGLONG:
 class ULONG32:
 	def __init__(self, reader):
 		self.value = int.from_bytes(reader.read(4), byteorder = 'little', signed = False)
-		
+
 class ULONG64:
 	def __init__(self, reader):
 		self.value = int.from_bytes(reader.read(8), byteorder = 'little', signed = False)
-		
+
 class PWSTR(POINTER):
 	def __init__(self, reader):
 		super().__init__(reader, None)
-		
+
 class PCHAR(POINTER):
 	def __init__(self, reader):
 		super().__init__(reader, CHAR)
-		
+
 class USHORT:
 	def __init__(self, reader):
 		self.value = int.from_bytes(reader.read(2), byteorder = 'little', signed = False)
-		
+
 class SHORT:
 	def __init__(self, reader):
 		self.value = int.from_bytes(reader.read(2), byteorder = 'little', signed = True)
-		
+
 #https://msdn.microsoft.com/en-us/library/windows/hardware/ff554296(v=vs.85).aspx
 class LIST_ENTRY:
 	def __init__(self, reader, finaltype = None):
 		self.Flink = POINTER(reader, finaltype)
 		self.Blink = POINTER(reader, finaltype)
-		
+
 class FILETIME:
 	def __init__(self, reader):
 		self.dwLowDateTime = DWORD(reader)
 		self.dwHighDateTime = DWORD(reader)
 		self.value = (self.dwHighDateTime.value << 32) + self.dwLowDateTime.value
-		
+
 class PUCHAR(POINTER):
 	def __init__(self, reader):
 		super().__init__(reader, UCHAR)
-		
+
 class PCWSTR(POINTER):
 	def __init__(self, reader):
 		super().__init__(reader, None)
-		
+
 class SIZE_T:
 	def __init__(self, reader):
 		self.value = reader.read_uint()
-		
-		
 
-		
+
+

--- a/minidump/writer.py
+++ b/minidump/writer.py
@@ -118,7 +118,7 @@ class LiveSystemReader(MinidumpSystemReader):
 			mmod.ModuleName = modname
 
 			module_list.Modules.append(mmod)
-		
+
 		return module_list
 
 	def get_sections(self):
@@ -149,11 +149,11 @@ class LiveSystemReader(MinidumpSystemReader):
 
 			meminfolist.entries.append(mi)
 			print(str(mi))
-			
+
 			i += mi_raw.RegionSize
 		self.meminfolist = meminfolist
 		return meminfolist
-	
+
 	def get_threads(self):
 		pass
 
@@ -219,24 +219,24 @@ class MinidumpWriter:
 			self.header_buffer.write(directory.to_bytes())
 
 	def finalize_header(self):
-		# currently only using the 32 bit MINIDUMP_LOCATION_DESCRIPTOR, this is because we expect that the header 
+		# currently only using the 32 bit MINIDUMP_LOCATION_DESCRIPTOR, this is because we expect that the header
 		# and any data in the header (including all streams data except memory stream) will not be bigger than 4GB
-		# memory stream is a special case, as it cvan be longer than 4GB but the RVA to the beginning of the memory stream 
+		# memory stream is a special case, as it cvan be longer than 4GB but the RVA to the beginning of the memory stream
 		# is not expected to be bigger than 4G max.
 		# if this becomes the case then this all will fail :)
 		header_size = 28
 		header_size += len(self.streams) * 8 #this is for the dictionary itself, not the streams
 		for stream in self.streams:
 			header_size += self.streams[stream].get_size()
-		
+
 		header_size += 10 * 1024 #allocating 10k for the memory info
 
 		self.prepare_header()
 		self.prepare_directory()
 
-		
-		
-		
+
+
+
 
 	def create_streams(self):
 		sysinfo = self.sysreader.get_sysinfo()
@@ -245,32 +245,32 @@ class MinidumpWriter:
 		print(str(sysinfo))
 		moduleinfo = self.sysreader.get_modules()
 		self.streams[MINIDUMP_STREAM_TYPE.ModuleListStream] = moduleinfo
-		
+
 		sections = self.sysreader.get_sections()
 		self.streams[MINIDUMP_STREAM_TYPE.MemoryInfoListStream] = sections
-		
+
 		self.finalize_header()
 
 		memory = self.sysreader.get_memory()
-		
-		
+
+
 	#def get_total_streams_cnt(self):
 	#	total = 0
 	#	for t in self.streams:
 	#		total += len(t)
 	#	return total
 
-	
 
-		
+
+
 
 	#def construct_directory(self):
 	#
 	#	total_streams = self.get_total_streams_cnt()
 	#
-	#	for stype in self.streams:			
+	#	for stype in self.streams:
 	#		for stream in self.streams[stype]:
-	#			
+	#
 	#			stream
 	#
 	#			loc = MINIDUMP_LOCATION_DESCRIPTOR()
@@ -295,13 +295,13 @@ class MinidumpWriter:
 		#modules
 		#self.sysreader.get_modules(self.hdr_buff, self.data_buff)
 		#self.stream_cnt += 1
-		
+
 		#write header
 		self.write_header()
-		
+
 
 		#append datastream for memory, with correct rva
-		
+
 		#dump memory
 
 	def run(self):


### PR DESCRIPTION
Closes #35

I forgot to fix the other uses of `inrange` back in #28 ([relevant diff](https://github.com/skelsec/minidump/pull/28/commits/1e75e5927feaac08617f1199d53f4296c88e2f40#diff-fc08232255dd0e3b2d1f5ab4f74dc04c776c50a91a35d0b27be96717d4481aecL185)).

I tested with 
[HarnessMinimal_x64.dmp.zip](https://github.com/skelsec/minidump/files/13629062/HarnessMinimal_x64.dmp.zip)
 and the following command now executes successfully:

```sh
minidump HarnessMinimal_x64.dmp -r 0x130000000 -s 0x1000
```

Output:
```
# minidump 0.0.22
# Author: Tamas Jos @skelsec (skelsecprojects@gmail.com)

130000000(+0000):  4d 5a 90 00 03 00 00 00  04 00 00 00 ff ff 00 00   |MZ..............|
130000010(+0010):  b8 00 00 00 00 00 00 00  40 00 00 00 00 00 00 00   |........@.......|
130000020(+0020):  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   |................|
130000030(+0030):  00 00 00 00 00 00 00 00  00 00 00 00 c8 00 00 00   |................|
130000040(+0040):  0e 1f ba 0e 00 b4 09 cd  21 b8 01 4c cd 21 54 68   |........!..L.!Th|
130000050(+0050):  69 73 20 70 72 6f 67 72  61 6d 20 63 61 6e 6e 6f   |is program canno|
130000060(+0060):  74 20 62 65 20 72 75 6e  20 69 6e 20 44 4f 53 20   |t be run in DOS |
<snip>
130000fc0(+0fc0):  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   |................|
130000fd0(+0fd0):  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   |................|
130000fe0(+0fe0):  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   |................|
130000ff0(+0ff0):  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   |................|
```