### PR TITLE
fix: MINIDUMP_EXCEPTION parsing

### DIFF
--- a/minidump/streams/ExceptionStream.py
+++ b/minidump/streams/ExceptionStream.py
@@ -139,6 +139,7 @@ class MINIDUMP_EXCEPTION:
 		for _ in range(self.EXCEPTION_MAXIMUM_PARAMETERS):
 			me.ExceptionInformation.append(int.from_bytes(buff.read(8), byteorder = 'little', signed = False))
 
+		me.ExceptionInformation = me.ExceptionInformation[:me.NumberParameters]
 		return me
 
 	def __str__(self):

--- a/minidump/streams/ExceptionStream.py
+++ b/minidump/streams/ExceptionStream.py
@@ -110,6 +110,8 @@ class ExceptionCode(enum.Enum):
 
 #https://msdn.microsoft.com/en-us/library/windows/desktop/ms680367(v=vs.85).aspx
 class MINIDUMP_EXCEPTION:
+	EXCEPTION_MAXIMUM_PARAMETERS = 15
+
 	def __init__(self):
 		self.ExceptionCode = None
 		self.ExceptionFlags = None
@@ -134,7 +136,7 @@ class MINIDUMP_EXCEPTION:
 		me.ExceptionAddress = int.from_bytes(buff.read(8), byteorder = 'little', signed = False)
 		me.NumberParameters = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		me.__unusedAlignment = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
-		for _ in range(me.NumberParameters):
+		for _ in range(self.EXCEPTION_MAXIMUM_PARAMETERS):
 			me.ExceptionInformation.append(int.from_bytes(buff.read(8), byteorder = 'little', signed = False))
 
 		return me


### PR DESCRIPTION
# Context
A friend of mine was trying this library because he needs to parse some minidumps for a private project. Everything worked fine, except for the `MINIDUMP_EXCEPTION` parsing. Since the code wasn't actually considering the size of `ExceptionInformation`, it was leading to incorrect parsing of `ThreadContext` from `MINIDUMP_EXCEPTION_STREAM`.

# Solution
Very simple! Just read the entire field and then copy the actual parameters, which is what this PR achieves.