### PR TITLE
removes incorrect duplicate parsing of TimeDateStamp

### DIFF
--- a/minidump/header.py
+++ b/minidump/header.py
@@ -11,7 +11,6 @@ class MinidumpHeader:
 		self.NumberOfStreams:int = None
 		self.StreamDirectoryRva:int = None
 		self.CheckSum:int = 0
-		self.Reserved:int = 0
 		self.TimeDateStamp:int = 0
 		self.Flags:MINIDUMP_TYPE = None
 
@@ -22,7 +21,6 @@ class MinidumpHeader:
 		t += self.NumberOfStreams.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.StreamDirectoryRva.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.CheckSum.to_bytes(4, byteorder = 'little', signed = False)
-		t += self.Reserved.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.TimeDateStamp.to_bytes(4, byteorder = 'little', signed = False)
 		t += self.Flags.value.to_bytes(4, byteorder = 'little', signed = False)
 
@@ -61,7 +59,6 @@ class MinidumpHeader:
 		t+= 'NumberOfStreams: %s\n' % self.NumberOfStreams
 		t+= 'StreamDirectoryRva: %s\n' % self.StreamDirectoryRva
 		t+= 'CheckSum: %s\n' % self.CheckSum
-		t+= 'Reserved: %s\n' % self.Reserved
 		t+= 'TimeDateStamp: %s\n' % self.TimeDateStamp
 		t+= 'Flags: %s\n' % self.Flags
 		return t

--- a/minidump/header.py
+++ b/minidump/header.py
@@ -39,7 +39,6 @@ class MinidumpHeader:
 		mh.NumberOfStreams = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mh.StreamDirectoryRva = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mh.CheckSum = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
-		mh.Reserved = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		mh.TimeDateStamp = int.from_bytes(buff.read(4), byteorder = 'little', signed = False)
 		try:
 			mh.Flags = MINIDUMP_TYPE(int.from_bytes(buff.read(4), byteorder = 'little', signed = False))

--- a/minidump/writer.py
+++ b/minidump/writer.py
@@ -204,7 +204,6 @@ class MinidumpWriter:
 		self.header.NumberOfStreams = len(self.streams) +1 # +1 is fot he memory info stream
 		self.header.StreamDirectoryRva = self.directory_rva
 		#self.header.CheckSum = None
-		#self.header.Reserved = None
 		#self.header.TimeDateStamp = None
 		self.header.Flags = MINIDUMP_TYPE.MiniDumpWithFullMemory
 		self.header_buffer.write(self.header.to_bytes())


### PR DESCRIPTION
I ran into an issue where the `TimeDateStamp` value computed by `minidump` was incorrect. When inspecting the code, I noticed that both the `Reserved` and `TimeDateStamp` field were being read as consecutive 32-bit integers:

https://github.com/skelsec/minidump/blob/c60f39da26f5d432b86411b9b13effab80a767ab/minidump/header.py#L42-L43

This is incorrect, see also the [official Microsoft documentation](https://learn.microsoft.com/de-de/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_header?utm_source=chatgpt.com):
```c
typedef struct _MINIDUMP_HEADER {
  ULONG32 Signature;
  ULONG32 Version;
  ULONG32 NumberOfStreams;
  RVA     StreamDirectoryRva;
  ULONG32 CheckSum;
  union {
    ULONG32 Reserved;
    ULONG32 TimeDateStamp;
  };
  ULONG64 Flags;
} MINIDUMP_HEADER, *PMINIDUMP_HEADER;
```
The `Reserved` and `TimeDateStamp` field are _the same value_ since they are in a `union`. This PR fixes this bug.