### PR TITLE
changed PROCESSOR_ARCHITECTURE(enum.Enum).AARCH64 = 12

### DIFF
--- a/minidump/streams/SystemInfoStream.py
+++ b/minidump/streams/SystemInfoStream.py
@@ -57,7 +57,7 @@ class PROCESSOR_ARCHITECTURE(enum.Enum):
 	ARM = 5 #ARM
 	IA64 = 6 #Intel Itanium
 	INTEL = 0 #x86
-	AARCH64 = 0x8003 #ARM64
+	AARCH64 = 12 #ARM64
 	UNKNOWN = 0xffff #Unknown processor
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms680396(v=vs.85).aspx
 class PROCESSOR_LEVEL(enum.Enum):


### PR DESCRIPTION
## Problem

The `PROCESSOR_ARCHITECTURE` enum in `minidump/streams/SystemInfoStream.py` defines:

    AARCH64 = 0x8003 #ARM64

This value is incorrect. Windows reports ARM64 processor architecture as `12`, not `0x8003`. As a result, parsing any minidump captured on a Windows-on-ARM system (e.g. Windows 11 ARM64, including under emulation via QEMU/UTM on Apple Silicon) fails with:

    ValueError: 12 is not a valid PROCESSOR_ARCHITECTURE

This happens during `MINIDUMP_SYSTEM_INFO.parse()`, before any actual thread/module/memory data can be read — so the entire dump becomes unparseable, not just the sysinfo section.

## Fix

One-line change:

    AARCH64 = 12 #ARM64

## References

[Win32_Processor class — Architecture property](https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-processor), Microsoft Learn — confirms ARM64 = 12.

## Testing

Reproduced and fixed against a real minidump captured from a deadlocked Java process running inside a Windows 11 ARM64 VM (QEMU/UTM on Apple Silicon). Before the fix: `minidump --all` raised `ValueError` immediately. After the fix: parses successfully, including `--sysinfo`, `--threads`, and `--all`.


<img width="686" height="471" alt="minidump-output" src="https://github.com/user-attachments/assets/5f7dc526-7e71-43f5-9289-c47f9d5f851b" />
